### PR TITLE
added gentle/GT for AC2939

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -280,7 +280,8 @@
           "bacteria": "bacteria",
           "night": "night",
           "turbo": "turbo",
-          "automode": "automode"
+          "automode": "automode",
+	  "gentle": "gentle"
         },
         "read": true,
         "write": true

--- a/lib/coap.js
+++ b/lib/coap.js
@@ -31,7 +31,7 @@ const NAME_MAPPING = {
     Runtime:     {name: 'uptime', device: true},
     pm25:        {name: 'pm25'},
     tvoc:        {name: 'totalVolatileOrganicCompounds'},
-    mode:        {name: 'mode', options: {'P': 'auto', 'A': 'allergen', 'S': 'sleep', 'M': 'manual', 'B': 'bacteria', 'N': 'night', 'T': 'turbo',  'AG': 'automode'}, control: true},
+    mode:        {name: 'mode', options: {'P': 'auto', 'A': 'allergen', 'S': 'sleep', 'M': 'manual', 'B': 'bacteria', 'N': 'night', 'T': 'turbo',  'AG': 'automode', 'GT': 'gentle'}, control: true},
     ddp:         {name: 'usedIndex', options: {'3': 'humidity', '1': 'pm2.5', '0': 'iai'}, control: true},
     rddp:        {name: 'rddp'},
     dt:          {name: 'timerHours', control: true},


### PR DESCRIPTION
added GT (gentle) to send via coap as mode for "schonender modus".

Overall AC2939 supports following modes: 
- AG/ automode
- T/ turbo
- GT/ gentle
- S/ sleep