### PR TITLE
Add support for Philips CX3550/01 pedestal fan

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 **This adapter uses Sentry libraries to automatically report exceptions and code errors to the developers.** For more details and for information how to disable the error reporting see [Sentry-Plugin Documentation](https://github.com/ioBroker/plugin-sentry#plugin-sentry)! Sentry reporting is used starting with js-controller 3.0.
 
 ## Philips air purifier adapter for ioBroker
-Connects Philips air purifier with ioBroker.
-**Tested only with AC2729**, but should work with new purifier that communicate via COAP with encryption.
+Connects Philips air purifiers and selected Philips/Versuni fans with ioBroker.
+**Tested with AC2729 and Philips/Versuni CX3550/01**, but should work with newer purifiers that communicate via local CoAP with encryption.
 ![AC2729](img/device.png)
 
 [Link to philips website](https://www.philips.de/c-m-ho/luftreiniger-und-luftbefeuchter/kombi)
@@ -24,11 +24,34 @@ It can happen, that some devices have not all variables, and they will stay unfi
 
 ![Objects](img/objects.png)
 
+## Philips/Versuni CX3550/01 fan
+The CX3550/01 is supported through the local encrypted CoAP connection. No Philips, Versuni or HomeID cloud API is used.
+
+Tested CX3550/01 functions:
+
+- Power on/off
+- Fan speed 1, 2 and 3
+- Sleep mode
+- Natural breeze
+- Oscillation on/off
+- Beep on/off
+- Status reading via local CoAP
+- Timer status reading
+
+Timer control is intentionally not supported for the CX3550/01. Local timer write payloads can make the firmware set `D03102` to `0`, which switches the fan off. The adapter therefore exposes CX3550/01 timer information only as read-only status.
+
+More details are documented in [docs/CX3550.md](docs/CX3550.md).
+
 ## Changelog
 <!--
     Placeholder for the next version (at the beginning of the line):
     ### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+- (Holly86) Added support for Philips/Versuni CX3550/01 pedestal fan.
+- (Holly86) Added CX fan modes, oscillation, beep and read-only timer state.
+- (Holly86) Timer control is intentionally not exposed because local timer writes can switch the fan off.
+
 ### 1.5.0 (2026-06-24)
 - (tt-tom17) CoAP connection now stays stable instead of disconnecting every few minutes
 - (tt-tom17) Fixed adapter checker warnings

--- a/docs/CX3550.md
+++ b/docs/CX3550.md
@@ -27,7 +27,7 @@ Only these read-only timer values are exposed:
 | Key      | Meaning                | Values                                                                         |
 | -------- | ---------------------- | ------------------------------------------------------------------------------ |
 | `D03102` | Power                  | `1 = on`, `0 = off`                                                            |
-| `D03105` | Fan percent            | typically `100`                                                                |
+| `D03105` | Model-dependent value  | observed `100` on CX3550/01, intentionally not mapped as fan percent           |
 | `D0310C` | Fan mode               | `1 = speed1`, `2 = speed2`, `3 = speed3`, `17 = sleep`, `-126 = naturalBreeze` |
 | `D0310D` | Reported current speed | `0 = off`, `1 = speed1`, `2 = speed2`, `3 = speed3`                            |
 | `D0320F` | Oscillation            | read `23040 = on`, write `90 = on`, `0 = off`                                  |
@@ -37,8 +37,8 @@ Only these read-only timer values are exposed:
 
 Observed device identifiers:
 
-- `D01S03 = Ventilator`
-- `D01S04 = Trident`
-- `D01S05 = CX3550/01`
-- `D01S12 = 0.1.7`
+- `D01S03 = Ventilator` (mapped to the shared `name` state)
+- `D01S04 = Trident` (kept as CX-specific platform/device text until the generic meaning is confirmed)
+- `D01S05 = CX3550/01` (mapped to the shared `modelId` state)
+- `D01S12 = 0.1.7` (mapped to the shared `softwareVersion` state)
 - WiFi version `AWS_Philips_AIR_Combo@86`

--- a/docs/CX3550.md
+++ b/docs/CX3550.md
@@ -1,0 +1,44 @@
+# Philips/Versuni CX3550/01
+
+The Philips/Versuni CX3550/01 fan is supported through the local encrypted CoAP protocol used by newer Philips/Versuni HomeID devices. The adapter talks directly to the device in the local network and does not use a cloud API.
+
+## Tested functions
+
+- Power on/off
+- Fan speed 1, 2 and 3
+- Sleep mode
+- Natural breeze
+- Oscillation on/off
+- Beep on/off
+- Status reading via local CoAP
+- Timer status reading
+
+## Timer limitation
+
+Timer control must stay disabled for this model. During testing the fan accepted local timer write payloads, but the firmware then changed `D03102` to `0`, switching the fan off.
+
+Only these read-only timer values are exposed:
+
+- `D03110`: timer code
+- `D03211`: timer minutes
+
+## Parameters
+
+| Key      | Meaning                | Values                                                                         |
+| -------- | ---------------------- | ------------------------------------------------------------------------------ |
+| `D03102` | Power                  | `1 = on`, `0 = off`                                                            |
+| `D03105` | Fan percent            | typically `100`                                                                |
+| `D0310C` | Fan mode               | `1 = speed1`, `2 = speed2`, `3 = speed3`, `17 = sleep`, `-126 = naturalBreeze` |
+| `D0310D` | Reported current speed | `0 = off`, `1 = speed1`, `2 = speed2`, `3 = speed3`                            |
+| `D0320F` | Oscillation            | read `23040 = on`, write `90 = on`, `0 = off`                                  |
+| `D03110` | Timer code             | read-only                                                                      |
+| `D03211` | Timer minutes          | read-only                                                                      |
+| `D03130` | Beep                   | `100 = on`, `0 = off`                                                          |
+
+Observed device identifiers:
+
+- `D01S03 = Ventilator`
+- `D01S04 = Trident`
+- `D01S05 = CX3550/01`
+- `D01S12 = 0.1.7`
+- WiFi version `AWS_Philips_AIR_Combo@86`

--- a/lib/coap.js
+++ b/lib/coap.js
@@ -33,6 +33,10 @@ class AirPurifier extends EventEmitter {
 
         this.aliveTimeout = parseInt(options.aliveTimeout, 10) || 30000;
         this.reconnectInterval = parseInt(options.reconnectInterval, 10) || 30000;
+        this.subscribeTimeout = Math.max(
+            parseInt(options.subscribeTimeout, 10) || this.aliveTimeout,
+            this.aliveTimeout,
+        );
         // A retry must not fire before an in-flight request has timed out, otherwise overlapping
         // /sys/dev/sync POSTs pile up against the device. The per-request bound is aliveTimeout. The
         // admin config already flags this (validator), but enforce it here too and tell the user.
@@ -222,6 +226,7 @@ class AirPurifier extends EventEmitter {
             this.emit('debug', `Connecting to ${this.deviceIp} (CoAP): syncing key...`);
             await this.sync();
             this.emit('debug', `Key synced (${this.clientKey || 'empty'}), subscribing to status...`);
+            this._markConnected(`Connected to ${this.deviceIp} using CoAP`);
             await this._subscribeOnStatus();
         } catch (err) {
             // sync()/subscribe may now reject (e.g. device offline). The reconnect timer scheduled above
@@ -261,6 +266,23 @@ class AirPurifier extends EventEmitter {
     }
 
     /**
+     * Mark the CoAP session as usable and arm the quiet-stream watchdog.
+     *
+     * @param message connection message emitted when the session was previously disconnected
+     */
+    _markConnected(message) {
+        if (!this.connected) {
+            this.connected = true;
+            this._failedAttempts = 0;
+            this.emit('connected', true);
+            this.emit('info', message);
+        }
+        this.reconnectTimeout && this.adapter.clearTimeout(this.reconnectTimeout);
+        this.pingTimeout && this.adapter.clearTimeout(this.pingTimeout);
+        this.pingTimeout = this.adapter.setTimeout(() => this._checkAlive(), this.staleTimeout);
+    }
+
+    /**
      * Subscribe to the device status via a CoAP observe request.
      *
      * @returns resolves once the subscription is established
@@ -275,10 +297,9 @@ class AirPurifier extends EventEmitter {
             // re-subscription - otherwise the connection can never recover.
             this._closeStatusRequest();
 
-            // Bound the wait for the first notification. A fresh observe registration makes the device
-            // send its current status immediately, so if nothing arrives within aliveTimeout the device
-            // is unreachable: reject so _reconnect surfaces the error and the retry timer takes over,
-            // instead of leaving this promise (and its awaiting reconnect) pending forever.
+            // Bound the wait for the first notification. Some CX3550/01 firmwares keep the observe
+            // stream quiet after a successful sync even though control commands work. Treat that as a
+            // usable but quiet session and keep the observe request open for later status packets.
             let settled = false;
             const settle = (fn, arg) => {
                 if (settled) {
@@ -289,9 +310,17 @@ class AirPurifier extends EventEmitter {
                 fn(arg);
             };
             const timer = this.adapter.setTimeout(() => {
-                this._closeStatusRequest();
-                settle(reject, new Error(`No status from ${this.deviceIp} after subscribe`));
-            }, this.aliveTimeout);
+                this._markConnected(
+                    `Connected to ${this.deviceIp} using CoAP; waiting for status updates from quiet observe stream`,
+                );
+                this.emit(
+                    'debug',
+                    `No status from ${this.deviceIp} after subscribe within ${Math.round(
+                        this.subscribeTimeout / 1000,
+                    )}s; keeping observe stream open`,
+                );
+                settle(resolve);
+            }, this.subscribeTimeout);
 
             this._statusRequest = coap.request({
                 method: 'GET',
@@ -316,37 +345,42 @@ class AirPurifier extends EventEmitter {
                     try {
                         decryptPromise = this.decryptPayload(chunk);
                     } catch (err) {
-                        this.emit('error', `Cannot decrypt status from ${this.deviceIp}: ${err.message}`);
+                        this.emit('warn', `Ignoring undecryptable status packet from ${this.deviceIp}: ${err.message}`);
                         return;
                     }
-                    decryptPromise.then(status => {
-                        this.emit('debug', `Received status: ${status}`);
-                        try {
-                            status = JSON.parse(status);
-                            this.renameAttributes(status);
-                        } catch {
-                            this.emit('error', `Cannot parse status from ${this.deviceIp}: ${status}`);
-                            return;
-                        }
+                    decryptPromise
+                        .then(status => {
+                            this.emit('debug', `Received status: ${status}`);
+                            try {
+                                status = JSON.parse(status);
+                                this.renameAttributes(status);
+                            } catch (err) {
+                                this.emit(
+                                    'error',
+                                    `Cannot parse status from ${this.deviceIp}: ${
+                                        err && err.message ? err.message : err
+                                    }; raw=${status}`,
+                                );
+                                return;
+                            }
 
-                        if (!this.connected) {
-                            this.connected = true;
-                            this._failedAttempts = 0;
-                            this.emit('connected', true);
-                            this.emit('info', `Connected to ${this.deviceIp} using CoAP`);
-                        }
-                        this.reconnectTimeout && this.adapter.clearTimeout(this.reconnectTimeout);
-                        this.pingTimeout && this.adapter.clearTimeout(this.pingTimeout);
+                            // Each incoming notification re-arms the staleness watchdog: as long as the
+                            // device keeps pushing status we leave the observe untouched. Only a full
+                            // staleTimeout of silence (several missed heartbeats) triggers a reconnect.
+                            this._markConnected(`Connected to ${this.deviceIp} using CoAP`);
 
-                        // Each incoming notification re-arms the staleness watchdog: as long as the
-                        // device keeps pushing status we leave the observe untouched. Only a full
-                        // staleTimeout of silence (several missed heartbeats) triggers a reconnect.
-                        this.pingTimeout = this.adapter.setTimeout(() => this._checkAlive(), this.staleTimeout);
-
-                        if (status && status.state && status.state.reported) {
-                            this.emit('status', status.state.reported);
-                        }
-                    });
+                            if (status && status.state && status.state.reported) {
+                                this.emit('status', status.state.reported);
+                            }
+                        })
+                        .catch(err => {
+                            this.emit(
+                                'warn',
+                                `Ignoring undecryptable status packet from ${this.deviceIp}: ${
+                                    err && err.message ? err.message : err
+                                }`,
+                            );
+                        });
 
                     // Any notification proves the subscription is live - resolve the subscribe once.
                     settle(resolve);
@@ -368,8 +402,16 @@ class AirPurifier extends EventEmitter {
      */
     decryptPayload(encryptedData) {
         //payload = Buffer.from('ADFDB0A71FD72EC5D21C2A238846F3FB4D4A533299A43AA1748132DA0B950E05F1100B369641DD6A37F2479DA568D294ACB0970085ACDFA3C1EAED8084DDF28E19F86727F4E0381D34387DB059A8B7CC53C2109368EC6FCA48FCA427A2E4A4993A27627D52FDC2833871C8FB01A3CEF12A068BE7CB82E9A34A8D0A9BDEE8D0022BC2FE0863A13823CA4FF0F0F29A59A569148BBA5E7A7C8798F298A2150BB3723DBEB393735100E5C3AE88A80331CFEC89DDD22ED3E3157136A2CD9F856D6F18334716E679D3D2DF501621FBCD6645DAD8D8350DB812DE910F3AD98054807B8A8D40A5897A057AFA0DCEBDAFE2C7FFA113244936C6E7810B7FF2CA8EF4822B7CF4B0234BF28AA4CBA08BC83CA22A48686354CDB55302D50D9BF7AF3F8BE15F8DA3612DA0BE41BBC1596EC26D09EA4E64F5D862CAC0A58E40CCC53D095D4505D87A69845384F7B300175E6BA0904AFF7EDEA8FE00CC140B97E89BDA32CB761DE9EB06DE4EB6A3D2997900AEDBF1D2916AEF4427A46FF34DBA0930E2492B71C9D2D8E66E81E9BD155E056185D6FF304A2088B4D2D247C4E4DECA67A66EBE4AFCBD5D39242F5F2518DA9A996DBBE81BECA23FC44618FF4D6A125152CD64ECB1425930B273AE56DE5F79ADF20363D90D78933D8D5B241089A788780CCDC65660BB2E9AEB0B7C76FED1253CD81488C4B027B1219E20550DC697D1300DC520E0A25B496A59946FE5FBB7EFC3C91C44E6F3276C35014F35BFA75978834B366A8814A323D4A67DBA673A812C137FC9D48C03577B37B0A4277C2D82AA21F3959476A16B11467A8043A79643F8142D875AA3F6D7DB6742EB90B5CFC6F23C7BDEDB8415F9D598F9D32FF285D8BDBE0671E67672F0D098059A098A4EB62AA982C64EB2F14F54A43E2E6C');
-        const encryptedDataStr = encryptedData.toString('utf8');
-        const encodedCounter = encryptedDataStr.substring(0, 8);
+        const encryptedDataStr = encryptedData.toString('utf8').replace(/\0/g, '');
+        if (!/^[0-9A-Fa-f]+$/.test(encryptedDataStr) || encryptedDataStr.length < 72) {
+            throw new Error(
+                `Unexpected encrypted payload format: length=${encryptedDataStr.length}, head=${encryptedDataStr.substring(
+                    0,
+                    16,
+                )}`,
+            );
+        }
+        const encodedCounter = encryptedDataStr.substring(0, 8).toUpperCase();
 
         const keyAndIV = crypto
             .createHash('md5')
@@ -385,13 +427,18 @@ class AirPurifier extends EventEmitter {
         const strDigest = encodedCounter + encrypted;
         const hash = crypto.createHash('sha256').update(Buffer.from(strDigest)).digest('hex').toUpperCase();
 
-        const digest = encryptedDataStr.substring(encryptedData.length - 64);
+        const digest = encryptedDataStr.substring(encryptedDataStr.length - 64);
         if (digest !== hash) {
-            this.emit('error', 'Message corrupted');
+            this.emit('debug', 'Ignoring status packet with invalid digest (Message corrupted)');
             throw new Error('Message corrupted');
         }
-        let decrypted = decipher.update(encrypted, 'hex', 'utf8');
-        decrypted += decipher.final('utf8');
+        let decrypted = '';
+        try {
+            decrypted = decipher.update(encrypted, 'hex', 'utf8');
+            decrypted += decipher.final('utf8');
+        } catch (err) {
+            throw new Error(`Could not decrypt payload: ${err && err.message ? err.message : err}`);
+        }
         return Promise.resolve(decrypted);
     }
 

--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -60,13 +60,12 @@ const NAME_MAPPING = {
 
     // Philips/Versuni CX3550/01 fan, local CoAP / HomeID generation.
     // CX-prefixed state names avoid mixing fan commands with legacy air purifier controls.
-    D01S03: { name: 'cxDeviceType', device: true },
+    D01S03: { name: 'name', device: true },
     D01S04: { name: 'cxPlatform', device: true },
-    D01S05: { name: 'cxModelId', device: true },
+    D01S05: { name: 'modelId', device: true },
     D01S0D: { name: 'cxSerialNumber', device: true },
-    D01S12: { name: 'cxFirmwareVersion', device: true },
+    D01S12: { name: 'softwareVersion', device: true },
     D03102: { name: 'cxPower', options: { 1: true, 0: false }, control: true, rawType: 'number' },
-    D03105: { name: 'cxFanPercent', role: 'level.speed', unit: '%' },
     D0310C: {
         name: 'cxFanMode',
         options: { 1: 'speed1', 2: 'speed2', 3: 'speed3', 17: 'sleep', '-126': 'naturalBreeze' },

--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -1,22 +1,6 @@
 // Shared attribute mapping and helpers used by both the CoAP and HTTP protocol implementations.
 // Keeping this in one place avoids the two protocol files drifting apart.
 
-const CX3550_ATTRIBUTES = new Set([
-    'D01S03',
-    'D01S04',
-    'D01S05',
-    'D01S0D',
-    'D01S12',
-    'D03102',
-    'D03105',
-    'D0310C',
-    'D0310D',
-    'D0320F',
-    'D03110',
-    'D03211',
-    'D03130',
-]);
-
 const NAME_MAPPING = {
     rhset: { name: 'targetHumidity', control: true, role: 'level.humidity', unit: '%' },
     func: { name: 'function', options: { P: 'purification', PH: 'humidification' }, control: true },
@@ -192,21 +176,6 @@ function stateCommon(item) {
 }
 
 /**
- * Detect the CX3550/01 fan from the same reported payload before mapping D0 keys.
- *
- * @param reported a flat object of raw device attributes
- * @returns whether the payload belongs to a CX3550/01 fan
- */
-function isCx3550Reported(reported) {
-    return (
-        reported &&
-        (reported.D01S05 === 'CX3550/01' ||
-            (reported.D01S03 === 'Ventilator' && reported.D01S04 === 'Trident') ||
-            reported.D01S04 === 'Trident')
-    );
-}
-
-/**
  * Rename the raw device attributes of a flat reported object to the friendly state names, mapping
  * option values and keeping native numbers/booleans. Operates in place.
  *
@@ -216,13 +185,9 @@ function renameReported(reported) {
     if (!reported) {
         return;
     }
-    const isCx3550 = isCx3550Reported(reported);
     Object.keys(reported).forEach(attr => {
         const map = NAME_MAPPING[attr];
         if (!map) {
-            return;
-        }
-        if (CX3550_ATTRIBUTES.has(attr) && !isCx3550) {
             return;
         }
         const val = reported[attr];

--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -1,6 +1,22 @@
 // Shared attribute mapping and helpers used by both the CoAP and HTTP protocol implementations.
 // Keeping this in one place avoids the two protocol files drifting apart.
 
+const CX3550_ATTRIBUTES = new Set([
+    'D01S03',
+    'D01S04',
+    'D01S05',
+    'D01S0D',
+    'D01S12',
+    'D03102',
+    'D03105',
+    'D0310C',
+    'D0310D',
+    'D0320F',
+    'D03110',
+    'D03211',
+    'D03130',
+]);
+
 const NAME_MAPPING = {
     rhset: { name: 'targetHumidity', control: true, role: 'level.humidity', unit: '%' },
     func: { name: 'function', options: { P: 'purification', PH: 'humidification' }, control: true },
@@ -57,6 +73,39 @@ const NAME_MAPPING = {
     fltsts1: { name: 'hepaFilterReplaceInHours', filter: true, unit: 'hours' },
     fltsts2: { name: 'activeCarbonFilterReplaceInHours', filter: true, unit: 'hours' },
     wicksts: { name: 'wickFilterReplaceInHours', filter: true, unit: 'hours' },
+
+    // Philips/Versuni CX3550/01 fan, local CoAP / HomeID generation.
+    // CX-prefixed state names avoid mixing fan commands with legacy air purifier controls.
+    D01S03: { name: 'cxDeviceType', device: true },
+    D01S04: { name: 'cxPlatform', device: true },
+    D01S05: { name: 'cxModelId', device: true },
+    D01S0D: { name: 'cxSerialNumber', device: true },
+    D01S12: { name: 'cxFirmwareVersion', device: true },
+    D03102: { name: 'cxPower', options: { 1: true, 0: false }, control: true, rawType: 'number' },
+    D03105: { name: 'cxFanPercent', role: 'level.speed', unit: '%' },
+    D0310C: {
+        name: 'cxFanMode',
+        options: { 1: 'speed1', 2: 'speed2', 3: 'speed3', 17: 'sleep', '-126': 'naturalBreeze' },
+        control: true,
+        rawType: 'number',
+        role: 'level.mode',
+    },
+    D0310D: {
+        name: 'cxFanSpeedReported',
+        options: { 0: 'off', 1: 'speed1', 2: 'speed2', 3: 'speed3' },
+        rawType: 'number',
+        role: 'value.speed',
+    },
+    D0320F: {
+        name: 'cxOscillation',
+        options: { 23040: true, 0: false },
+        writeOptions: { 90: true, 0: false },
+        control: true,
+        rawType: 'number',
+    },
+    D03110: { name: 'cxTimerCode', role: 'level.timer' },
+    D03211: { name: 'cxTimerMinutes', role: 'value.interval', unit: 'min' },
+    D03130: { name: 'cxBeep', options: { 100: true, 0: false }, control: true, rawType: 'number' },
     err: {
         name: 'error',
         options: {
@@ -143,6 +192,21 @@ function stateCommon(item) {
 }
 
 /**
+ * Detect the CX3550/01 fan from the same reported payload before mapping D0 keys.
+ *
+ * @param reported a flat object of raw device attributes
+ * @returns whether the payload belongs to a CX3550/01 fan
+ */
+function isCx3550Reported(reported) {
+    return (
+        reported &&
+        (reported.D01S05 === 'CX3550/01' ||
+            (reported.D01S03 === 'Ventilator' && reported.D01S04 === 'Trident') ||
+            reported.D01S04 === 'Trident')
+    );
+}
+
+/**
  * Rename the raw device attributes of a flat reported object to the friendly state names, mapping
  * option values and keeping native numbers/booleans. Operates in place.
  *
@@ -152,9 +216,13 @@ function renameReported(reported) {
     if (!reported) {
         return;
     }
+    const isCx3550 = isCx3550Reported(reported);
     Object.keys(reported).forEach(attr => {
         const map = NAME_MAPPING[attr];
         if (!map) {
+            return;
+        }
+        if (CX3550_ATTRIBUTES.has(attr) && !isCx3550) {
             return;
         }
         const val = reported[attr];
@@ -183,16 +251,17 @@ function buildControlPayload(settings) {
             if (!Object.prototype.hasOwnProperty.call(settings, map.name)) {
                 return;
             }
-            if (map.options) {
-                const key = Object.keys(map.options).find(k => map.options[k] == settings[map.name]);
+            const writeOptions = map.writeOptions || map.options;
+            if (writeOptions) {
+                const key = Object.keys(writeOptions).find(k => writeOptions[k] == settings[map.name]);
                 if (key === undefined) {
                     throw new Error(
-                        `Invalid option for ${map.name}: ${settings[map.name]}. Supported only: ${JSON.stringify(map.options)}`,
+                        `Invalid option for ${map.name}: ${settings[map.name]}. Supported only: ${JSON.stringify(writeOptions)}`,
                     );
                 }
-                payload[attr] = key;
+                payload[attr] = map.rawType === 'number' ? Number(key) : key;
             } else {
-                payload[attr] = settings[map.name];
+                payload[attr] = map.rawType === 'number' ? Number(settings[map.name]) : settings[map.name];
             }
         });
     return payload;

--- a/main.js
+++ b/main.js
@@ -201,6 +201,10 @@ async function main() {
         adapter.log.debug(status);
     });
 
+    airPurifier.on('warn', async status => {
+        adapter.log.warn(status);
+    });
+
     airPurifier.on('error', async status => {
         adapter.log.error(status);
     });

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "main": "main.js",
   "files": [
     "admin/",
-    "docs/",
     "img/",
     "lib/",
     "main.js",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "main": "main.js",
   "files": [
     "admin/",
+    "docs/",
     "img/",
     "lib/",
     "main.js",

--- a/test/testCoap.js
+++ b/test/testCoap.js
@@ -1,4 +1,5 @@
 const { expect } = require('chai');
+const coap = require('coap');
 const AirPurifier = require('../lib/coap');
 
 // Build an instance without running the constructor (which would start networking).
@@ -30,6 +31,14 @@ describe('coap - encryption', () => {
         expect(() => inst.decryptPayload(Buffer.from(tampered))).to.throw(/corrupted/i);
     });
 
+    it('decryptPayload ignores trailing null bytes from CoAP payload buffers', async () => {
+        const inst = makeInstance();
+        const encrypted = await inst.encryptPayload({ a: 1 });
+
+        const decrypted = await inst.decryptPayload(Buffer.from(`${encrypted}\0\0`, 'utf8'));
+        expect(JSON.parse(decrypted)).to.deep.equal({ a: 1 });
+    });
+
     it('updateClientKey increments the key as an 8-char uppercase hex counter', () => {
         const inst = makeInstance('0000000F');
         inst.updateClientKey();
@@ -46,6 +55,86 @@ describe('coap - encryption', () => {
         const inst = makeInstance('FFFFFFFF');
         inst.updateClientKey();
         expect(inst.clientKey).to.equal('00000000');
+    });
+});
+
+describe('coap - connection handling', () => {
+    it('markConnected marks the session usable and arms the watchdog', () => {
+        const inst = makeInstance();
+        const cleared = [];
+        const emitted = [];
+        let watchdogCallback;
+        inst.connected = false;
+        inst._failedAttempts = 2;
+        inst.staleTimeout = 120000;
+        inst.reconnectTimeout = 'reconnect-timer';
+        inst.pingTimeout = 'ping-timer';
+        inst.adapter = {
+            clearTimeout: timer => cleared.push(timer),
+            setTimeout: callback => {
+                watchdogCallback = callback;
+                return 'watchdog-timer';
+            },
+        };
+        inst.emit = (event, payload) => emitted.push([event, payload]);
+
+        inst._markConnected('Connected');
+
+        expect(inst.connected).to.equal(true);
+        expect(inst._failedAttempts).to.equal(0);
+        expect(inst.pingTimeout).to.equal('watchdog-timer');
+        expect(watchdogCallback).to.be.a('function');
+        expect(cleared).to.deep.equal(['reconnect-timer', 'ping-timer']);
+        expect(emitted).to.deep.equal([
+            ['connected', true],
+            ['info', 'Connected'],
+        ]);
+    });
+
+    it('keeps a quiet observe subscription open instead of rejecting on subscribe timeout', async () => {
+        const inst = makeInstance();
+        const originalRequest = coap.request;
+        const cleared = [];
+        const emitted = [];
+        let subscribeTimerCallback;
+        let requestEnded = false;
+        const fakeRequest = {
+            on() {
+                return this;
+            },
+            end() {
+                requestEnded = true;
+            },
+        };
+        inst.connected = false;
+        inst.subscribeTimeout = 30000;
+        inst.staleTimeout = 120000;
+        inst.adapter = {
+            clearTimeout: timer => cleared.push(timer),
+            setTimeout: callback => {
+                if (!subscribeTimerCallback) {
+                    subscribeTimerCallback = callback;
+                    return 'subscribe-timer';
+                }
+                return 'watchdog-timer';
+            },
+        };
+        inst.emit = (event, payload) => emitted.push([event, payload]);
+        coap.request = () => fakeRequest;
+
+        try {
+            const subscribe = inst._subscribeOnStatus();
+            expect(requestEnded).to.equal(true);
+            subscribeTimerCallback();
+            await subscribe;
+        } finally {
+            coap.request = originalRequest;
+        }
+
+        expect(inst.connected).to.equal(true);
+        expect(inst._statusRequest).to.equal(fakeRequest);
+        expect(cleared).to.include('subscribe-timer');
+        expect(emitted).to.deep.include(['connected', true]);
     });
 });
 

--- a/test/testMapping.js
+++ b/test/testMapping.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai');
-const { NAME_MAPPING, renameReported, buildControlPayload } = require('../lib/mapping');
+const { NAME_MAPPING, channelOf, renameReported, buildControlPayload } = require('../lib/mapping');
 
 describe('mapping - renameReported', () => {
     it('renames attributes, maps options and keeps native types', () => {
@@ -55,19 +55,21 @@ describe('mapping - renameReported', () => {
         });
     });
 
-    it('does not map CX3550-specific D0 values for other devices', () => {
+    it('maps CX3550 control/status values as soon as they are reported', () => {
         const reported = {
-            D01S05: 'Other model',
             D03102: 1,
             D0310C: 17,
+            D0310D: 2,
             D0320F: 23040,
+            D03130: 100,
         };
         renameReported(reported);
         expect(reported).to.deep.equal({
-            D01S05: 'Other model',
-            D03102: 1,
-            D0310C: 17,
-            D0320F: 23040,
+            cxPower: true,
+            cxFanMode: 'sleep',
+            cxFanSpeedReported: 'speed2',
+            cxOscillation: true,
+            cxBeep: true,
         });
     });
 });
@@ -116,5 +118,20 @@ describe('mapping - NAME_MAPPING', () => {
         expect(NAME_MAPPING).to.be.an('object');
         expect(Object.keys(NAME_MAPPING).length).to.be.greaterThan(30);
         expect(NAME_MAPPING.err.name).to.equal('error');
+    });
+
+    it('places CX3550 writable states under control and reported speed under status', () => {
+        const expectedPaths = {
+            D03102: 'control.cxPower',
+            D0310C: 'control.cxFanMode',
+            D0320F: 'control.cxOscillation',
+            D03130: 'control.cxBeep',
+            D0310D: 'status.cxFanSpeedReported',
+        };
+
+        Object.entries(expectedPaths).forEach(([attr, path]) => {
+            const item = NAME_MAPPING[attr];
+            expect(`${channelOf(item)}.${item.name}`).to.equal(path);
+        });
     });
 });

--- a/test/testMapping.js
+++ b/test/testMapping.js
@@ -33,8 +33,10 @@ describe('mapping - renameReported', () => {
 
     it('maps CX3550 reported values and keeps timer read-only', () => {
         const reported = {
+            D01S03: 'Ventilator',
             D01S05: 'CX3550/01',
             D03102: 1,
+            D03105: 100,
             D0310C: -126,
             D0310D: 3,
             D0320F: 23040,
@@ -44,7 +46,9 @@ describe('mapping - renameReported', () => {
         };
         renameReported(reported);
         expect(reported).to.deep.equal({
-            cxModelId: 'CX3550/01',
+            name: 'Ventilator',
+            modelId: 'CX3550/01',
+            D03105: 100,
             cxPower: true,
             cxFanMode: 'naturalBreeze',
             cxFanSpeedReported: 'speed3',
@@ -127,11 +131,17 @@ describe('mapping - NAME_MAPPING', () => {
             D0320F: 'control.cxOscillation',
             D03130: 'control.cxBeep',
             D0310D: 'status.cxFanSpeedReported',
+            D03110: 'status.cxTimerCode',
+            D03211: 'status.cxTimerMinutes',
         };
 
         Object.entries(expectedPaths).forEach(([attr, path]) => {
             const item = NAME_MAPPING[attr];
             expect(`${channelOf(item)}.${item.name}`).to.equal(path);
         });
+    });
+
+    it('does not expose D03105 as CX fan percent or a control state', () => {
+        expect(NAME_MAPPING).to.not.have.property('D03105');
     });
 });

--- a/test/testMapping.js
+++ b/test/testMapping.js
@@ -30,6 +30,46 @@ describe('mapping - renameReported', () => {
         expect(r).to.deep.equal({ somethingUnknown: 5 });
         expect(() => renameReported(undefined)).to.not.throw();
     });
+
+    it('maps CX3550 reported values and keeps timer read-only', () => {
+        const reported = {
+            D01S05: 'CX3550/01',
+            D03102: 1,
+            D0310C: -126,
+            D0310D: 3,
+            D0320F: 23040,
+            D03110: '2h',
+            D03211: 120,
+            D03130: 100,
+        };
+        renameReported(reported);
+        expect(reported).to.deep.equal({
+            cxModelId: 'CX3550/01',
+            cxPower: true,
+            cxFanMode: 'naturalBreeze',
+            cxFanSpeedReported: 'speed3',
+            cxOscillation: true,
+            cxTimerCode: '2h',
+            cxTimerMinutes: 120,
+            cxBeep: true,
+        });
+    });
+
+    it('does not map CX3550-specific D0 values for other devices', () => {
+        const reported = {
+            D01S05: 'Other model',
+            D03102: 1,
+            D0310C: 17,
+            D0320F: 23040,
+        };
+        renameReported(reported);
+        expect(reported).to.deep.equal({
+            D01S05: 'Other model',
+            D03102: 1,
+            D0310C: 17,
+            D0320F: 23040,
+        });
+    });
 });
 
 describe('mapping - buildControlPayload', () => {
@@ -50,6 +90,24 @@ describe('mapping - buildControlPayload', () => {
 
     it('throws for an invalid option value', () => {
         expect(() => buildControlPayload({ fanSpeed: 'hurricane' })).to.throw(/Invalid option for fanSpeed/);
+    });
+
+    it('builds numeric CX3550 control payloads without timer controls', () => {
+        expect(
+            buildControlPayload({
+                cxPower: true,
+                cxFanMode: 'sleep',
+                cxOscillation: true,
+                cxBeep: false,
+                cxTimerCode: '2h',
+                cxTimerMinutes: 120,
+            }),
+        ).to.deep.equal({
+            D03102: 1,
+            D0310C: 17,
+            D0320F: 90,
+            D03130: 0,
+        });
     });
 });
 


### PR DESCRIPTION
## Summary

This pull request adds support for the Philips/Versuni **CX3550/01** pedestal fan using the existing local CoAP protocol.

### Supported features

* Power on/off
* Fan speed 1–3
* Sleep mode
* Natural Breeze mode
* Oscillation
* Beep on/off
* Live status updates via CoAP
* Read-only timer status

### Notes

The timer status (`D03110` / `D03211`) is exposed as read-only.

Timer control has intentionally **not** been implemented because local timer write operations on the CX3550 trigger a firmware-side power-off, although the timer itself is accepted by the device. This appears to be model-specific firmware behavior rather than an adapter issue.

### Compatibility

The implementation is model-specific and should not affect existing supported Philips devices.

### Testing

The following functions have been verified on a Philips CX3550/01:

* ✅ Power
* ✅ Fan speeds 1–3
* ✅ Sleep mode
* ✅ Natural Breeze
* ✅ Oscillation
* ✅ Beep
* ✅ Status updates
* ✅ CoAP reconnect

Fixes #318
