### PR TITLE
feat: model-based mapping — add AC3221 support & device-model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Philips air purifier adapter for ioBroker
 Connects Philips air purifiers and selected Philips/Versuni fans with ioBroker.
-**Tested with AC2729 and Philips/Versuni CX3550/01**, but should work with newer purifiers that communicate via local CoAP with encryption.
+**Tested with AC2729 and the Philips/Versuni fans CX3550/01 and CX7550/01**, but should work with newer purifiers that communicate via local CoAP with encryption.
 ![AC2729](img/device.png)
 
 [Link to philips website](https://www.philips.de/c-m-ho/luftreiniger-und-luftbefeuchter/kombi)
@@ -42,14 +42,33 @@ Timer control is intentionally not supported for the CX3550/01. Local timer writ
 
 More details are documented in [docs/CX3550.md](docs/CX3550.md).
 
+## Philips/Versuni CX7550/01 tower fan
+The CX7550/01 ("Smart Tower Fan 7000 series") uses the same local encrypted CoAP connection, but different raw values than the CX3550/01 - select `CX7550` as the device model.
+
+Tested CX7550/01 functions:
+
+- Power on/off
+- Fan speeds 1 to 12 and AutoAdapt
+- Sleep mode
+- Natural breeze
+- Oscillation on/off
+- Timer (off, 1 to 12 hours) - writable on this model
+- Beep on/off
+- Display brightness, temperature colour display and what the display shows permanently
+- Room temperature
+
+More details are documented in [docs/CX7550.md](docs/CX7550.md).
+
 ## Changelog
 <!--
     Placeholder for the next version (at the beginning of the line):
     ### **WORK IN PROGRESS**
 -->
 ### **WORK IN PROGRESS**
-- (tt-tom17) New "Device model" setting: pick your model (AC2889, AC3221, CX3550 or Generic) so the adapter shows the correct controls for your device
+- (tt-tom17) New "Device model" setting: pick your model (AC2889, AC3221, CX3550, CX7550 or Generic) so the adapter shows the correct controls for your device
 - (tt-tom17) Added support for the AC3221 next-generation purifier (power, fan speed/mode, display brightness, child lock, beep and more)
+- (DrBakterius) Added support for the CX7550/01 tower fan (all 12 speeds, AutoAdapt, sleep, natural breeze, oscillation, writable timer, display settings and room temperature)
+- (tt-tom17) Fixed switches that did nothing when a script or visualisation wrote them as the text "true"/"false" instead of a real on/off value
 - (tt-tom17) The adapter now warns in the log when the selected model does not seem to match the connected device
 - (tt-tom17) Device diagnostics such as Wi-Fi signal and free memory are now shown; unrecognised values are collected under "unknownStates"
 - (tt-tom17) BREAKING for CX3550: all state IDs starting with "cx" were renamed to generic names (for example "fanMode" instead of "cxFanMode"). Please select your model once in the settings; the old "cx*" objects can be deleted manually

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ More details are documented in [docs/CX3550.md](docs/CX3550.md).
     Placeholder for the next version (at the beginning of the line):
     ### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+- (tt-tom17) New "Device model" setting: pick your model (AC2889, AC3221, CX3550 or Generic) so the adapter shows the correct controls for your device
+- (tt-tom17) Added support for the AC3221 next-generation purifier (power, fan speed/mode, display brightness, child lock, beep and more)
+- (tt-tom17) The adapter now warns in the log when the selected model does not seem to match the connected device
+- (tt-tom17) Device diagnostics such as Wi-Fi signal and free memory are now shown; unrecognised values are collected under "unknownStates"
+- (tt-tom17) BREAKING for CX3550: all state IDs starting with "cx" were renamed to generic names (for example "fanMode" instead of "cxFanMode"). Please select your model once in the settings; the old "cx*" objects can be deleted manually
+
 ### 1.6.1 (2026-07-03)
 - (Holly86) Added support for Philips/Versuni CX3550/01 pedestal fan.
 - (Holly86) Added CX fan modes, oscillation, beep and read-only timer state.

--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -6,5 +6,7 @@
     "Reconnect interval": "Wiederverbindungsintervall",
     "ms": "ms",
     "ms - should be >= Alive timeout": "ms – sollte >= Alive-Timeout sein",
-    "Reconnect interval should be at least the Alive timeout": "Das Wiederverbindungsintervall sollte mindestens dem Alive-Timeout entsprechen"
+    "Reconnect interval should be at least the Alive timeout": "Das Wiederverbindungsintervall sollte mindestens dem Alive-Timeout entsprechen",
+    "Device model": "Gerätemodell",
+    "Selects which controls are created for your device. Choose \"Generic\" if your model is not listed (read-only, no controls).": "Legt fest, welche Bedienelemente für Ihr Gerät angelegt werden. Wählen Sie \"Generic\", wenn Ihr Modell nicht aufgeführt ist (schreibgeschützt, keine Bedienelemente)."
 }

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -6,5 +6,7 @@
     "Enter a valid IP address or hostname (no http://, no spaces)": "Enter a valid IP address or hostname (no http://, no spaces)",
     "ms": "ms",
     "ms - should be >= Alive timeout": "ms - should be >= Alive timeout",
-    "Reconnect interval should be at least the Alive timeout": "Reconnect interval should be at least the Alive timeout"
+    "Reconnect interval should be at least the Alive timeout": "Reconnect interval should be at least the Alive timeout",
+    "Device model": "Device model",
+    "Selects which controls are created for your device. Choose \"Generic\" if your model is not listed (read-only, no controls).": "Selects which controls are created for your device. Choose \"Generic\" if your model is not listed (read-only, no controls)."
 }

--- a/admin/i18n/es/translations.json
+++ b/admin/i18n/es/translations.json
@@ -6,5 +6,7 @@
     "Reconnect interval": "Intervalo de reconexión",
     "ms": "ms",
     "ms - should be >= Alive timeout": "ms - debe ser >= tiempo de espera de actividad",
-    "Reconnect interval should be at least the Alive timeout": "El intervalo de reconexión debe ser al menos el tiempo de espera de actividad"
+    "Reconnect interval should be at least the Alive timeout": "El intervalo de reconexión debe ser al menos el tiempo de espera de actividad",
+    "Device model": "Modelo del dispositivo",
+    "Selects which controls are created for your device. Choose \"Generic\" if your model is not listed (read-only, no controls).": "Determina qué controles se crean para su dispositivo. Elija \"Generic\" si su modelo no aparece en la lista (solo lectura, sin controles)."
 }

--- a/admin/i18n/fr/translations.json
+++ b/admin/i18n/fr/translations.json
@@ -6,5 +6,7 @@
     "Reconnect interval": "Intervalle de reconnexion",
     "ms": "ms",
     "ms - should be >= Alive timeout": "ms - doit être >= délai d'activité (Alive timeout)",
-    "Reconnect interval should be at least the Alive timeout": "L'intervalle de reconnexion doit être au moins égal au délai d'activité (Alive timeout)"
+    "Reconnect interval should be at least the Alive timeout": "L'intervalle de reconnexion doit être au moins égal au délai d'activité (Alive timeout)",
+    "Device model": "Modèle de l'appareil",
+    "Selects which controls are created for your device. Choose \"Generic\" if your model is not listed (read-only, no controls).": "Détermine quels contrôles sont créés pour votre appareil. Choisissez \"Generic\" si votre modèle n'est pas répertorié (lecture seule, sans contrôles)."
 }

--- a/admin/i18n/it/translations.json
+++ b/admin/i18n/it/translations.json
@@ -6,5 +6,7 @@
     "Reconnect interval": "Intervallo di riconnessione",
     "ms": "ms",
     "ms - should be >= Alive timeout": "ms - deve essere >= timeout di attività",
-    "Reconnect interval should be at least the Alive timeout": "L'intervallo di riconnessione deve essere almeno pari al timeout di attività"
+    "Reconnect interval should be at least the Alive timeout": "L'intervallo di riconnessione deve essere almeno pari al timeout di attività",
+    "Device model": "Modello del dispositivo",
+    "Selects which controls are created for your device. Choose \"Generic\" if your model is not listed (read-only, no controls).": "Determina quali comandi vengono creati per il tuo dispositivo. Scegli \"Generic\" se il tuo modello non è elencato (sola lettura, senza comandi)."
 }

--- a/admin/i18n/nl/translations.json
+++ b/admin/i18n/nl/translations.json
@@ -6,5 +6,7 @@
     "Reconnect interval": "Interval opnieuw verbinden",
     "ms": "ms",
     "ms - should be >= Alive timeout": "ms - moet >= Alive-timeout zijn",
-    "Reconnect interval should be at least the Alive timeout": "Het herverbindingsinterval moet minstens gelijk zijn aan de Alive-timeout"
+    "Reconnect interval should be at least the Alive timeout": "Het herverbindingsinterval moet minstens gelijk zijn aan de Alive-timeout",
+    "Device model": "Apparaatmodel",
+    "Selects which controls are created for your device. Choose \"Generic\" if your model is not listed (read-only, no controls).": "Bepaalt welke bedieningselementen voor uw apparaat worden aangemaakt. Kies \"Generic\" als uw model niet vermeld staat (alleen-lezen, geen bedieningselementen)."
 }

--- a/admin/i18n/pl/translations.json
+++ b/admin/i18n/pl/translations.json
@@ -6,5 +6,7 @@
     "Reconnect interval": "Interwał ponownego połączenia",
     "ms": "ms",
     "ms - should be >= Alive timeout": "ms - powinno być >= limit czasu aktywności",
-    "Reconnect interval should be at least the Alive timeout": "Interwał ponownego połączenia powinien wynosić co najmniej limit czasu aktywności"
+    "Reconnect interval should be at least the Alive timeout": "Interwał ponownego połączenia powinien wynosić co najmniej limit czasu aktywności",
+    "Device model": "Model urządzenia",
+    "Selects which controls are created for your device. Choose \"Generic\" if your model is not listed (read-only, no controls).": "Określa, które elementy sterujące zostaną utworzone dla Twojego urządzenia. Wybierz \"Generic\", jeśli Twój model nie jest wymieniony na liście (tylko do odczytu, bez elementów sterujących)."
 }

--- a/admin/i18n/pt/translations.json
+++ b/admin/i18n/pt/translations.json
@@ -6,5 +6,7 @@
     "Reconnect interval": "Intervalo de reconexão",
     "ms": "ms",
     "ms - should be >= Alive timeout": "ms - deve ser >= tempo limite de atividade",
-    "Reconnect interval should be at least the Alive timeout": "O intervalo de reconexão deve ser pelo menos o tempo limite de atividade"
+    "Reconnect interval should be at least the Alive timeout": "O intervalo de reconexão deve ser pelo menos o tempo limite de atividade",
+    "Device model": "Modelo do dispositivo",
+    "Selects which controls are created for your device. Choose \"Generic\" if your model is not listed (read-only, no controls).": "Determina quais controles são criados para o seu dispositivo. Escolha \"Generic\" se o seu modelo não estiver listado (somente leitura, sem controles)."
 }

--- a/admin/i18n/ru/translations.json
+++ b/admin/i18n/ru/translations.json
@@ -6,5 +6,7 @@
     "Reconnect interval": "Интервал повторного подключения",
     "ms": "мс",
     "ms - should be >= Alive timeout": "мс — должно быть >= тайм-аута активности",
-    "Reconnect interval should be at least the Alive timeout": "Интервал переподключения должен быть не меньше тайм-аута активности"
+    "Reconnect interval should be at least the Alive timeout": "Интервал переподключения должен быть не меньше тайм-аута активности",
+    "Device model": "Модель устройства",
+    "Selects which controls are created for your device. Choose \"Generic\" if your model is not listed (read-only, no controls).": "Определяет, какие элементы управления создаются для вашего устройства. Выберите \"Generic\", если ваша модель не указана в списке (только чтение, без элементов управления)."
 }

--- a/admin/i18n/uk/translations.json
+++ b/admin/i18n/uk/translations.json
@@ -6,5 +6,7 @@
     "Reconnect interval": "Інтервал повторного підключення",
     "ms": "мс",
     "ms - should be >= Alive timeout": "мс — має бути >= тайм-аут активності",
-    "Reconnect interval should be at least the Alive timeout": "Інтервал перепідключення має бути не меншим за тайм-аут активності"
+    "Reconnect interval should be at least the Alive timeout": "Інтервал перепідключення має бути не меншим за тайм-аут активності",
+    "Device model": "Модель пристрою",
+    "Selects which controls are created for your device. Choose \"Generic\" if your model is not listed (read-only, no controls).": "Визначає, які елементи керування створюються для вашого пристрою. Виберіть \"Generic\", якщо вашої моделі немає в списку (лише читання, без елементів керування)."
 }

--- a/admin/i18n/zh-cn/translations.json
+++ b/admin/i18n/zh-cn/translations.json
@@ -6,5 +6,7 @@
     "Reconnect interval": "重连间隔",
     "ms": "毫秒",
     "ms - should be >= Alive timeout": "毫秒 - 应 >= 活动超时",
-    "Reconnect interval should be at least the Alive timeout": "重连间隔应至少为活动超时时间"
+    "Reconnect interval should be at least the Alive timeout": "重连间隔应至少为活动超时时间",
+    "Device model": "设备型号",
+    "Selects which controls are created for your device. Choose \"Generic\" if your model is not listed (read-only, no controls).": "决定为您的设备创建哪些控制项。如果列表中没有您的型号，请选择 \"Generic\"（只读，无控制项）。"
 }

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -82,6 +82,10 @@
           "value": "CX3550"
         },
         {
+          "label": "CX7550",
+          "value": "CX7550"
+        },
+        {
           "label": "Generic",
           "value": "Generic"
         }

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -64,6 +64,37 @@
       "md": 4,
       "lg": 4,
       "xl": 4
+    },
+    "model": {
+      "newLine": true,
+      "type": "select",
+      "options": [
+        {
+          "label": "AC2889",
+          "value": "AC2889"
+        },
+        {
+          "label": "AC3221",
+          "value": "AC3221"
+        },
+        {
+          "label": "CX3550",
+          "value": "CX3550"
+        },
+        {
+          "label": "Generic",
+          "value": "Generic"
+        }
+      ],
+      "noTranslation": true,
+      "label": "Device model",
+      "help": "Selects which controls are created for your device. Choose \"Generic\" if your model is not listed (read-only, no controls).",
+      "default": "AC2889",
+      "xs": 12,
+      "sm": 12,
+      "md": 4,
+      "lg": 4,
+      "xl": 4
     }
   }
 }

--- a/docs/CX7550.md
+++ b/docs/CX7550.md
@@ -1,0 +1,63 @@
+# Philips/Versuni CX7550/01
+
+The Philips/Versuni CX7550/01 tower fan ("Smart Tower Fan 7000 series") is supported through the local encrypted CoAP protocol used by newer Philips/Versuni HomeID devices. The adapter talks directly to the device in the local network and does not use a cloud API.
+
+The device reports itself as platform `Babel` (the CX3550/01 reports `Trident`). It shares the raw D-code namespace with the CX3550/01, but several codes carry different values, so the model has to be selected explicitly in the adapter settings.
+
+## Tested functions
+
+- Power on/off
+- Fan speeds 1 to 12
+- AutoAdapt
+- Sleep mode
+- Natural breeze
+- Oscillation on/off
+- Timer 1 to 12 hours (writable on this model)
+- Beep on/off
+- Display brightness
+- Temperature colour display on/off
+- Permanent display content (fan speed or temperature)
+- Room temperature reading
+
+## Differences from the CX3550/01
+
+| Function | CX3550/01 | CX7550/01 |
+| -------- | --------- | --------- |
+| Oscillation on | reads `23040`, writes `90` | reads and writes `80` |
+| Fan speeds | 1 to 3 | 1 to 12, plus AutoAdapt |
+| Timer | read-only (a write can switch the fan off) | writable |
+| Display | none | brightness, temperature colour, permanent content |
+| Room temperature | not reported | `D03224` |
+
+## Parameters
+
+| Key      | Meaning                        | Values                                                                                                  |
+| -------- | ------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `D03102` | Power                          | `1 = on`, `0 = off`                                                                                     |
+| `D03104` | Temperature colour display     | `100 = on`, `0 = off`                                                                                   |
+| `D03105` | Display brightness             | `0 = off`, `115 = low`, `123 = high`; drops to `115` by itself when the fan is switched off             |
+| `D0310C` | Fan mode                       | `0 = AutoAdapt`, `1`–`10 = speed1..speed10`, `81 = speed11`, `82 = speed12`, `17 = sleep`, `-126 = naturalBreeze` |
+| `D0310D` | Reported current speed         | `0 = off`, otherwise as `D0310C` without the named modes                                                |
+| `D03110` | Timer                          | `0 = off`, `2 = 1h`, `3 = 2h`, `4 = 3h`, `5 = 4h`, `6 = 5h`, `7 = 6h`, `8 = 7h`, `9 = 8h`, `10 = 9h`, `11 = 10h`, `12 = 11h`, `13 = 12h` |
+| `D03130` | Beep                           | `100 = on`, `0 = off`                                                                                   |
+| `D03211` | Timer minutes                  | read-only, matches the timer code                                                                       |
+| `D03224` | Room temperature               | tenths of a degree (`240 = 24.0 °C`), changes on its own                                                |
+| `D0312A` | Permanent display content      | `7 = fan speed`, `5 = temperature`                                                                      |
+| `D0312B` | Permanent display content (echoed by the device) | as `D0312A`, read-only                                                                |
+| `D0320F` | Oscillation                    | `80 = on`, `0 = off`                                                                                    |
+
+Timer code `1` is never emitted by the device. Code `5` (4 h) is interpolated from the surrounding sequence and was not confirmed directly.
+
+Observed device identifiers:
+
+- `D01S03 = Turmventilator` (mapped to the shared `name` state)
+- `D01S04 = Babel` (platform)
+- `D01S05 = CX7550/01` (mapped to the shared `modelId` state)
+- `D01S12 = 0.2.9` (mapped to the shared `softwareVersion` state)
+- WiFi version `AWS_Philips_AIR_Combo@86` (same as the CX3550/01)
+
+## Still undecoded
+
+`D0310A = 1`, `D03133 = 1`, `D03240 = 0` and `D0313B = 20` are part of every status frame but their meaning is unknown. They are deliberately left unmapped and appear read-only under `unknownStates.*`.
+
+Source of the decoding: [GitHub issue #372](https://github.com/iobroker-community-adapters/ioBroker.philips-air/issues/372) (DrBakterius, values captured by diffing the Philips app against the adapter debug log).

--- a/io-package.json
+++ b/io-package.json
@@ -237,6 +237,14 @@
         "name": "Device information"
       },
       "native": {}
+    },
+    {
+      "_id": "unknownStates",
+      "type": "channel",
+      "common": {
+        "name": "Unmapped raw device attributes"
+      },
+      "native": {}
     }
   ]
 }

--- a/io-package.json
+++ b/io-package.json
@@ -168,7 +168,8 @@
     "host": "",
     "aliveTimeout": 30000,
     "reconnectInterval": 30000,
-    "protocol": "coap"
+    "protocol": "coap",
+    "model": "AC2889"
   },
   "objects": [],
   "instanceObjects": [

--- a/lib/coap.js
+++ b/lib/coap.js
@@ -1,7 +1,7 @@
 const EventEmitter = require('node:events');
 const coap = require('coap');
 const crypto = require('node:crypto');
-const { NAME_MAPPING, renameReported, buildControlPayload } = require('./mapping');
+const { createMapping } = require('./mapping');
 
 const ALGORITHM = 'aes-128-cbc';
 const SECRET_KEY = 'JiangPan';
@@ -31,6 +31,10 @@ class AirPurifier extends EventEmitter {
 
         this.connected = false;
 
+        const m = createMapping(this.adapter.config.model);
+        this.renameReported = m.renameReported;
+        this.buildControlPayload = m.buildControlPayload;
+
         this.aliveTimeout = parseInt(options.aliveTimeout, 10) || 30000;
         this.reconnectInterval = parseInt(options.reconnectInterval, 10) || 30000;
         this.subscribeTimeout = Math.max(
@@ -55,13 +59,6 @@ class AirPurifier extends EventEmitter {
         // Defer the initial connect so the caller (main.js) can attach its event listeners first -
         // otherwise the first debug/error/info events emitted during connect would be lost.
         setImmediate(() => this._reconnect());
-    }
-
-    /**
-     * @returns the attribute name mapping used by this protocol
-     */
-    static getMapping() {
-        return NAME_MAPPING;
     }
 
     /**
@@ -494,7 +491,7 @@ class AirPurifier extends EventEmitter {
                     CommandType: 'app',
                     DeviceId: '',
                     EnduserId: '',
-                    ...buildControlPayload(settings),
+                    ...this.buildControlPayload(settings),
                 },
             },
         };
@@ -519,7 +516,7 @@ class AirPurifier extends EventEmitter {
      */
     renameAttributes(status) {
         if (status && status.state) {
-            renameReported(status.state.reported);
+            this.renameReported(status.state.reported);
         }
     }
 }

--- a/lib/http.js
+++ b/lib/http.js
@@ -1,6 +1,6 @@
 const EventEmitter = require('node:events');
 const HttpClient = require('./httpClient');
-const { NAME_MAPPING, renameReported, buildControlPayload } = require('./mapping');
+const { createMapping } = require('./mapping');
 
 // events:
 // - 'status', data
@@ -30,6 +30,10 @@ class AirPurifier extends EventEmitter {
         this.aliveTimeout = parseInt(options.aliveTimeout, 10) || 30000;
         this.reconnectInterval = parseInt(options.reconnectInterval, 10) || 30000;
 
+        const m = createMapping(this.adapter.config.model);
+        this.renameReported = m.renameReported;
+        this.buildControlPayload = m.buildControlPayload;
+
         this.adapter.getState('info.key', async (err, state) => {
             if (this.destroyed) {
                 return;
@@ -45,13 +49,6 @@ class AirPurifier extends EventEmitter {
             // Attempt the first connection immediately; sync() schedules its own retry on failure.
             this.sync();
         });
-    }
-
-    /**
-     * @returns the attribute name mapping used by this protocol
-     */
-    static getMapping() {
-        return NAME_MAPPING;
     }
 
     /**
@@ -181,7 +178,7 @@ class AirPurifier extends EventEmitter {
      * @returns the parsed device response
      */
     control(settings) {
-        const payload = buildControlPayload(settings);
+        const payload = this.buildControlPayload(settings);
 
         return this.client.setValues(payload).then(async data => {
             const key = this.client.key.toString('base64');
@@ -211,7 +208,7 @@ class AirPurifier extends EventEmitter {
      * @param status the parsed device status object
      */
     renameAttributes(status) {
-        renameReported(status);
+        this.renameReported(status);
     }
 }
 

--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -90,7 +90,8 @@ const STANDARD_MAPPING = {
         rawType: 'number',
         role: 'value.speed',
     },
-    // Timer write triggers a firmware bug that switches the device off - keep strictly read-only.
+    // Read-only by default: on the CX3550 a timer write triggers a firmware bug that switches the
+    // device off. Models that accept timer writes (CX7550) override this entry with a control.
     // Fan reports a code string (e.g. '2h'), so force the type explicitly instead of letting
     // inferType() default numeric D-codes to 'number'.
     D03110: { name: 'timerCode', type: 'string', role: 'text' },
@@ -179,6 +180,121 @@ const MODEL_MAPPING = {
         // hint (it is an AC3221 control). Not `control: true`, so buildControlPayload ignores them.
         D0310A: { name: 'D0310A', device: true, type: 'number', role: 'value' },
         D03105: { name: 'D03105', device: true, type: 'number', role: 'value' },
+    },
+
+    // Philips/Versuni CX7550/01 "Smart Tower Fan 7000 series" (platform "Babel", the CX3550 reports
+    // "Trident"). Decoded by DrBakterius against the Philips app, GitHub #372. It shares the D-code
+    // namespace with the CX3550 but uses different raw values for the same functions - the very
+    // reason the control table is model-bound.
+    CX7550: {
+        D03102: { name: 'power', options: { 1: true, 0: false }, control: true, rawType: 'number' },
+        // Twelve speeds plus AutoAdapt. Speeds 1-10 are the plain level, but 11 and 12 jump to
+        // 81/82 - not a linear encoding, so every value is listed verbatim.
+        D0310C: {
+            name: 'mode',
+            options: {
+                0: 'auto',
+                1: 'speed1',
+                2: 'speed2',
+                3: 'speed3',
+                4: 'speed4',
+                5: 'speed5',
+                6: 'speed6',
+                7: 'speed7',
+                8: 'speed8',
+                9: 'speed9',
+                10: 'speed10',
+                17: 'sleep',
+                81: 'speed11',
+                82: 'speed12',
+                '-126': 'naturalBreeze',
+            },
+            control: true,
+            rawType: 'number',
+            role: 'level.mode',
+        },
+        // Read-only override of the shared STANDARD entry, which only covers the levels the CX3550
+        // and AC3221 emit (0-4, 18) and would leave this fan's 5-12 as raw numbers.
+        D0310D: {
+            name: 'fanSpeedReported',
+            options: {
+                0: 'off',
+                1: 'speed1',
+                2: 'speed2',
+                3: 'speed3',
+                4: 'speed4',
+                5: 'speed5',
+                6: 'speed6',
+                7: 'speed7',
+                8: 'speed8',
+                9: 'speed9',
+                10: 'speed10',
+                81: 'speed11',
+                82: 'speed12',
+            },
+            rawType: 'number',
+            role: 'value.speed',
+        },
+        // This model reports AND writes raw 80 for "on" - unlike the CX3550, which reads 23040 and
+        // needs 90 on write. No writeOptions needed, read and write agree here.
+        D0320F: { name: 'oscillation', options: { 80: true, 0: false }, control: true, rawType: 'number' },
+        // Unlike the CX3550, this model accepts timer writes (confirmed on the device). Code 1 is
+        // never emitted; code 5 (4h) is interpolated from the surrounding sequence, not confirmed.
+        D03110: {
+            name: 'timerCode',
+            options: {
+                0: 'off',
+                2: '1h',
+                3: '2h',
+                4: '3h',
+                5: '4h',
+                6: '5h',
+                7: '6h',
+                8: '7h',
+                9: '8h',
+                10: '9h',
+                11: '10h',
+                12: '11h',
+                13: '12h',
+            },
+            control: true,
+            rawType: 'number',
+            // Dropdown of plain-text durations ('3h'), not a numeric level - so level.mode, not
+            // level.timer (which is what the numeric AC2889 `dt` timer uses).
+            role: 'level.mode',
+        },
+        D03130: { name: 'beep', options: { 100: true, 0: false }, control: true, rawType: 'number' },
+        // Display group. The AC3221 uses D03105 for its own brightness scale (and D0312A for the
+        // preferred index), which is why these can only ever be resolved per model. The device drops
+        // the brightness to 115 by itself when it is switched off; no 'auto' step observed here.
+        D03105: {
+            name: 'displayBrightness',
+            options: { 0: 'off', 115: 'low', 123: 'high' },
+            control: true,
+            rawType: 'number',
+            role: 'level.dimmer',
+        },
+        D03104: { name: 'temperatureColorDisplay', options: { 100: true, 0: false }, control: true, rawType: 'number' },
+        // What the display shows permanently. The device echoes the setting in D0312B.
+        D0312A: {
+            name: 'persistentDisplay',
+            options: { 5: 'temperature', 7: 'fanSpeed' },
+            control: true,
+            rawType: 'number',
+            role: 'level.mode',
+        },
+        D0312B: {
+            name: 'persistentDisplayReported',
+            options: { 5: 'temperature', 7: 'fanSpeed' },
+            rawType: 'number',
+            role: 'value',
+        },
+        // Room temperature in tenths of a degree (240 = 24.0 °C). Deliberately reuses the friendly
+        // name of the classic `temp` key - a device only ever sends one of the two.
+        D03224: { name: 'temperature', scale: 10, type: 'number', role: 'value.temperature', unit: '°C' },
+        // Also reported every frame, meaning unknown: D0310A=1, D03133=1, D03240=0, D0313B=20.
+        // Left unmapped on purpose so they surface under unknownStates.* instead of getting invented
+        // semantics. None of them is another model's control, so they cannot trip the wrong-model hint.
     },
 
     // AC3221 new-gen air purifier.
@@ -298,13 +414,29 @@ function stateCommon(item) {
 }
 
 /**
+ * Turn the strings "true"/"false" into real booleans, leaving every other value untouched.
+ *
+ * @param value a desired control value as it arrives from ioBroker
+ * @returns the value, with a stringified boolean converted to a real boolean
+ */
+function normalizeBooleanish(value) {
+    if (value === 'true') {
+        return true;
+    }
+    if (value === 'false') {
+        return false;
+    }
+    return value;
+}
+
+/**
  * Build the model-bound mapping and helpers for a given device model.
  *
  * Falls back to the AC2889 (classic) control set both when `model` is undefined (existing installs
  * without a configured model) AND when it is an unknown/mistyped model string - a plain `model ||
  * default` would only catch the first case, silently dropping all controls for a typo.
  *
- * @param model the configured device model (e.g. 'AC2889', 'AC3221', 'CX3550', 'Generic')
+ * @param model the configured device model (e.g. 'AC2889', 'AC3221', 'CX3550', 'CX7550', 'Generic')
  * @returns `{ mapping, channelOf, stateCommon, renameReported, buildControlPayload }` bound to the
  *   active (STANDARD + model) mapping
  */
@@ -333,6 +465,10 @@ function createMapping(model) {
             delete reported[attr];
             if (map.options && Object.prototype.hasOwnProperty.call(map.options, val)) {
                 reported[map.name] = map.options[val];
+            } else if (map.scale && typeof val === 'number') {
+                // Fixed-point registers, e.g. the CX7550 reports room temperature in tenths of a
+                // degree (raw 240 = 24.0 °C).
+                reported[map.name] = val / map.scale;
             } else {
                 // Keep native numbers/booleans so typed states are not rejected; coerce only the rest.
                 reported[map.name] = typeof val === 'number' || typeof val === 'boolean' ? val : (val ?? '').toString();
@@ -357,7 +493,13 @@ function createMapping(model) {
                 }
                 const writeOptions = map.writeOptions || map.options;
                 if (writeOptions) {
-                    const key = Object.keys(writeOptions).find(k => writeOptions[k] == settings[map.name]);
+                    // A boolean control can reach us as the string "true"/"false" (e.g. from a script
+                    // or a VIS widget writing the state as text). Loose equality does NOT help here -
+                    // `false == 'false'` is false, because the string is coerced to NaN - so the write
+                    // would find no matching option and be rejected as an invalid value. Normalize
+                    // first; option values themselves are never the strings "true"/"false".
+                    const target = normalizeBooleanish(settings[map.name]);
+                    const key = Object.keys(writeOptions).find(k => writeOptions[k] == target);
                     if (key === undefined) {
                         throw new Error(
                             `Invalid option for ${map.name}: ${settings[map.name]}. Supported only: ${JSON.stringify(writeOptions)}`,

--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -358,6 +358,22 @@ function createMapping(model) {
     return { mapping: activeMapping, channelOf, stateCommon, renameReported, buildControlPayload };
 }
 
+/**
+ * The model(s) whose control table claims a given raw device attribute. Turns an unknown-attribute
+ * log line into a targeted "wrong model?" hint: if a raw key the active mapping cannot resolve is a
+ * known control of another model, the user very likely picked the wrong device model. The active
+ * model's own controls never reach this path (they resolve to a friendly name), so the result only
+ * ever names OTHER models.
+ *
+ * @param rawKey a raw device attribute key (e.g. 'pwr', 'D03102')
+ * @returns the model names that expose this key as a control, or [] if none do
+ */
+function modelsOwningRawKey(rawKey) {
+    return Object.keys(MODEL_MAPPING).filter(model =>
+        Object.prototype.hasOwnProperty.call(MODEL_MAPPING[model], rawKey),
+    );
+}
+
 module.exports = {
     createMapping,
     STANDARD_MAPPING,
@@ -365,4 +381,5 @@ module.exports = {
     channelOf,
     inferType,
     stateCommon,
+    modelsOwningRawKey,
 };

--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -167,6 +167,14 @@ const MODEL_MAPPING = {
             rawType: 'number',
         },
         D03130: { name: 'beep', options: { 100: true, 0: false }, control: true, rawType: 'number' },
+        // The fan also reports D0310A (=1) and D03105 (=100) in every frame. kongo09's const.py maps
+        // these to circulation/heating and display-backlight on OTHER new-gen hardware, but the
+        // CX3550 is a plain fan with neither a heater nor any display/light, so their meaning here is
+        // unknown. Expose them read-only under their raw code (no invented semantics) so they stay
+        // out of unknownStates and, crucially, D03105 no longer trips the cross-model "wrong model?"
+        // hint (it is an AC3221 control). Not `control: true`, so buildControlPayload ignores them.
+        D0310A: { name: 'D0310A', device: true, type: 'number', role: 'value' },
+        D03105: { name: 'D03105', device: true, type: 'number', role: 'value' },
     },
 
     // AC3221 new-gen air purifier.
@@ -373,9 +381,12 @@ function createMapping(model) {
  * @returns the model names that expose this key as a control, or [] if none do
  */
 function modelsOwningRawKey(rawKey) {
-    return Object.keys(MODEL_MAPPING).filter(model =>
-        Object.prototype.hasOwnProperty.call(MODEL_MAPPING[model], rawKey),
-    );
+    // Only genuine controls count: some models also expose a raw register read-only (e.g. CX3550's
+    // diagnostic D0310A/D03105), which is not a wrong-model signal and must not be reported here.
+    return Object.keys(MODEL_MAPPING).filter(model => {
+        const entry = MODEL_MAPPING[model][rawKey];
+        return entry && entry.control;
+    });
 }
 
 module.exports = {

--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -29,6 +29,10 @@ const STANDARD_MAPPING = {
     ConnectType: { name: 'connectType', device: true },
     ota: { name: 'overTheAirUpdates', device: true },
     Runtime: { name: 'uptime', device: true, type: 'number', role: 'value.interval', unit: 'ms' },
+    // Classic AC2889-family diagnostics: present in every status frame but not controllable. Mapped
+    // read-only so they land in device.* instead of being reported as genuinely unknown attributes.
+    range: { name: 'range', device: true, type: 'string', role: 'text' },
+    aqit_ext: { name: 'airQualityThresholdExt', device: true, type: 'number', role: 'value' },
     pm25: { name: 'pm25', role: 'value' },
     tvoc: { name: 'totalVolatileOrganicCompounds', role: 'value' },
     rddp: { name: 'rddp' },

--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -1,24 +1,23 @@
 // Shared attribute mapping and helpers used by both the CoAP and HTTP protocol implementations.
 // Keeping this in one place avoids the two protocol files drifting apart.
+//
+// The mapping is layered by model because a handful of raw D-code attributes (notably D03102 /
+// D0310C / D03130) are reused by different device families with completely different semantics
+// (e.g. AC3221 air purifier vs. CX3550 fan). D-codes alone cannot disambiguate the device class, so
+// the adapter config picks the model and only ONE control table is active at a time:
+//
+//   STANDARD_MAPPING          - read-only across all models (sensors, filters, device-info, error, ...)
+//   MODEL_MAPPING[model]      - ONLY the read/write controls that differ per model
+//   createMapping(model)      - activeMapping = { ...STANDARD_MAPPING, ...MODEL_MAPPING[model] }
 
-const NAME_MAPPING = {
-    rhset: { name: 'targetHumidity', control: true, role: 'level.humidity', unit: '%' },
-    func: { name: 'function', options: { P: 'purification', PH: 'humidification' }, control: true },
-    pwr: { name: 'power', options: { 1: true, 0: false }, control: true },
-    om: {
-        name: 'fanSpeed',
-        options: { s: 'silent', t: 'turbo', a: 'auto', 1: '1', 2: '2', 3: '3' },
-        control: true,
-        role: 'level.speed',
-    },
-    aqil: { name: 'lightBrightness', control: true, role: 'level.brightness', unit: '%' },
-    aqit: { name: 'airQualityNotificationThreshold', control: true },
-    uil: { name: 'buttonLight', options: { 1: true, 0: false }, control: true },
+/**
+ * Read-only entries shared by all models: sensors, filters, device-info and error.
+ */
+const STANDARD_MAPPING = {
     rh: { name: 'humidity', role: 'value.humidity', unit: '%' },
     iaql: { name: 'allergenIndex', role: 'value' },
     temp: { name: 'temperature', role: 'value.temperature', unit: '°C' },
     wl: { name: 'waterLevel', role: 'value.fill', unit: '%' },
-    cl: { name: 'childLock', options: { 1: true, 0: false }, control: true },
     swversion: { name: 'softwareVersion', device: true },
     name: { name: 'name', device: true },
     type: { name: 'type', device: true },
@@ -32,24 +31,7 @@ const NAME_MAPPING = {
     Runtime: { name: 'uptime', device: true, type: 'number', role: 'value.interval', unit: 'ms' },
     pm25: { name: 'pm25', role: 'value' },
     tvoc: { name: 'totalVolatileOrganicCompounds', role: 'value' },
-    mode: {
-        name: 'mode',
-        options: {
-            P: 'auto',
-            A: 'allergen',
-            S: 'sleep',
-            M: 'manual',
-            B: 'bacteria',
-            N: 'night',
-            T: 'turbo',
-            AG: 'automode',
-            GT: 'gentle',
-        },
-        control: true,
-    },
-    ddp: { name: 'usedIndex', options: { 3: 'humidity', 1: 'pm2.5', 0: 'iai' }, control: true },
     rddp: { name: 'rddp' },
-    dt: { name: 'timerHours', control: true, role: 'level.timer', unit: 'hours' },
     dtrs: { name: 'timerMinutes', unit: 'min' },
     fltt1: { name: 'hepaFilterType', options: { A3: 'NanoProtect Filter Series 3 (FY2422)' }, filter: true },
     fltt2: { name: 'activeCarbonFilterType', options: { C7: 'NanoProtect Filter AC (FY2420)' }, filter: true },
@@ -58,37 +40,29 @@ const NAME_MAPPING = {
     fltsts2: { name: 'activeCarbonFilterReplaceInHours', filter: true, unit: 'hours' },
     wicksts: { name: 'wickFilterReplaceInHours', filter: true, unit: 'hours' },
 
-    // Philips/Versuni CX3550/01 fan, local CoAP / HomeID generation.
-    // CX-prefixed state names avoid mixing fan commands with legacy air purifier controls.
+    // Philips/Versuni CX3550/01 fan and AC3221 new-gen purifier, local CoAP / HomeID generation.
+    // Device-info D01S* keys use the same schema on both new-gen device families.
     D01S03: { name: 'name', device: true },
-    D01S04: { name: 'cxPlatform', device: true },
+    D01S04: { name: 'platform', device: true },
     D01S05: { name: 'modelId', device: true },
-    D01S0D: { name: 'cxSerialNumber', device: true },
+    D01S0D: { name: 'serialNumber', device: true },
     D01S12: { name: 'softwareVersion', device: true },
-    D03102: { name: 'cxPower', options: { 1: true, 0: false }, control: true, rawType: 'number' },
-    D0310C: {
-        name: 'cxFanMode',
-        options: { 1: 'speed1', 2: 'speed2', 3: 'speed3', 17: 'sleep', '-126': 'naturalBreeze' },
-        control: true,
-        rawType: 'number',
-        role: 'level.mode',
-    },
+
+    // Read-only, shared across new-gen models (no per-model semantic difference).
+    // CX3550 fan reports 0-3; AC3221 additionally reports 4 (speed4) and 18 (the shared max level,
+    // reported for both speed5 and turbo). Cover the union so no reported speed shows as a raw number.
     D0310D: {
-        name: 'cxFanSpeedReported',
-        options: { 0: 'off', 1: 'speed1', 2: 'speed2', 3: 'speed3' },
+        name: 'fanSpeedReported',
+        options: { 0: 'off', 1: 'speed1', 2: 'speed2', 3: 'speed3', 4: 'speed4', 18: 'max' },
         rawType: 'number',
         role: 'value.speed',
     },
-    D0320F: {
-        name: 'cxOscillation',
-        options: { 23040: true, 0: false },
-        writeOptions: { 90: true, 0: false },
-        control: true,
-        rawType: 'number',
-    },
-    D03110: { name: 'cxTimerCode', role: 'level.timer' },
-    D03211: { name: 'cxTimerMinutes', role: 'value.interval', unit: 'min' },
-    D03130: { name: 'cxBeep', options: { 100: true, 0: false }, control: true, rawType: 'number' },
+    // Timer write triggers a firmware bug that switches the device off - keep strictly read-only.
+    // Fan reports a code string (e.g. '2h'), so force the type explicitly instead of letting
+    // inferType() default numeric D-codes to 'number'.
+    D03110: { name: 'timerCode', type: 'string', role: 'text' },
+    D03211: { name: 'timerMinutes', role: 'value.interval', unit: 'min' },
+
     err: {
         name: 'error',
         options: {
@@ -102,6 +76,114 @@ const NAME_MAPPING = {
         },
         device: true,
     },
+};
+
+/**
+ * Per-model read/write controls. Only one model's table is merged into the active mapping at a
+ * time, which is what makes the D03102 / D0310C / D03130 raw-key overlap between AC3221 and
+ * CX3550 safe - they never coexist in the same active mapping.
+ */
+const MODEL_MAPPING = {
+    AC2889: {
+        rhset: { name: 'targetHumidity', control: true, role: 'level.humidity', unit: '%' },
+        func: { name: 'function', options: { P: 'purification', PH: 'humidification' }, control: true },
+        pwr: { name: 'power', options: { 1: true, 0: false }, control: true },
+        om: {
+            name: 'fanSpeed',
+            options: { s: 'silent', t: 'turbo', a: 'auto', 1: '1', 2: '2', 3: '3' },
+            control: true,
+            role: 'level.speed',
+        },
+        aqil: { name: 'lightBrightness', control: true, role: 'level.brightness', unit: '%' },
+        aqit: { name: 'airQualityNotificationThreshold', control: true },
+        uil: { name: 'buttonLight', options: { 1: true, 0: false }, control: true },
+        cl: { name: 'childLock', options: { 1: true, 0: false }, control: true },
+        mode: {
+            name: 'mode',
+            options: {
+                P: 'auto',
+                A: 'allergen',
+                S: 'sleep',
+                M: 'manual',
+                B: 'bacteria',
+                N: 'night',
+                T: 'turbo',
+                AG: 'automode',
+                GT: 'gentle',
+            },
+            control: true,
+        },
+        ddp: { name: 'usedIndex', options: { 3: 'humidity', 1: 'pm2.5', 0: 'iai' }, control: true },
+        dt: { name: 'timerHours', control: true, role: 'level.timer', unit: 'hours' },
+    },
+
+    // Philips/Versuni CX3550/01 fan. Friendly names are generic (no "cx" prefix) since only one
+    // model's controls are ever active at a time.
+    CX3550: {
+        D03102: { name: 'power', options: { 1: true, 0: false }, control: true, rawType: 'number' },
+        D0310C: {
+            name: 'mode',
+            options: { 1: 'speed1', 2: 'speed2', 3: 'speed3', 17: 'sleep', '-126': 'naturalBreeze' },
+            control: true,
+            rawType: 'number',
+            role: 'level.mode',
+        },
+        D0320F: {
+            name: 'oscillation',
+            options: { 23040: true, 0: false },
+            // Read reports raw 23040, but writing needs raw 90 - the device silently ignores 23040 on
+            // write. buildControlPayload() prefers writeOptions over options for exactly this reason.
+            writeOptions: { 90: true, 0: false },
+            control: true,
+            rawType: 'number',
+        },
+        D03130: { name: 'beep', options: { 100: true, 0: false }, control: true, rawType: 'number' },
+    },
+
+    // AC3221 new-gen air purifier.
+    AC3221: {
+        D03102: { name: 'power', options: { 1: true, 0: false }, control: true, rawType: 'number' },
+        // One attribute covers both fan speed levels and named modes; the device self-shifts speed
+        // while in auto mode. Corrected against live logs/App labels (GitHub #347): 0=auto (not
+        // sleep), 5=speed5 (not turbo), 17=sleep (not auto), 18=turbo, 19=medium (not autoMedium).
+        D0310C: {
+            name: 'mode',
+            options: {
+                '-16': 'off',
+                0: 'auto',
+                1: 'speed1',
+                2: 'speed2',
+                3: 'speed3',
+                4: 'speed4',
+                5: 'speed5',
+                17: 'sleep',
+                18: 'turbo',
+                19: 'medium',
+            },
+            control: true,
+            rawType: 'number',
+        },
+        // Display backlight. +100 offset, not linear: 101=auto (not low), 115=low (not mid).
+        D03105: {
+            name: 'displayBrightness',
+            options: { 0: 'off', 101: 'auto', 115: 'low', 123: 'high' },
+            control: true,
+            rawType: 'number',
+        },
+        D03135: {
+            name: 'lampMode',
+            options: { 0: 'off', 1: 'airQuality', 2: 'ambient' },
+            control: true,
+            rawType: 'number',
+        },
+        D03103: { name: 'childLock', options: { 1: true, 0: false }, control: true, rawType: 'number' },
+        D03130: { name: 'beep', options: { 100: true, 0: false }, control: true, rawType: 'number' },
+        D0312A: { name: 'preferredIndex', options: { 1: 'pm2.5' }, control: true, rawType: 'number' },
+        D03180: { name: 'autoPlusAi', options: { 1: true, 0: false }, control: true, rawType: 'number' },
+    },
+
+    // No device-specific controls; useful as an explicit "read-only" choice.
+    Generic: {},
 };
 
 /**
@@ -175,60 +257,87 @@ function stateCommon(item) {
 }
 
 /**
- * Rename the raw device attributes of a flat reported object to the friendly state names, mapping
- * option values and keeping native numbers/booleans. Operates in place.
+ * Build the model-bound mapping and helpers for a given device model.
  *
- * @param reported a flat object of raw device attributes (the "reported" status)
+ * Falls back to the AC2889 (classic) control set both when `model` is undefined (existing installs
+ * without a configured model) AND when it is an unknown/mistyped model string - a plain `model ||
+ * default` would only catch the first case, silently dropping all controls for a typo.
+ *
+ * @param model the configured device model (e.g. 'AC2889', 'AC3221', 'CX3550', 'Generic')
+ * @returns `{ mapping, channelOf, stateCommon, renameReported, buildControlPayload }` bound to the
+ *   active (STANDARD + model) mapping
  */
-function renameReported(reported) {
-    if (!reported) {
-        return;
-    }
-    Object.keys(reported).forEach(attr => {
-        const map = NAME_MAPPING[attr];
-        if (!map) {
+function createMapping(model) {
+    const controls = Object.prototype.hasOwnProperty.call(MODEL_MAPPING, model)
+        ? MODEL_MAPPING[model]
+        : MODEL_MAPPING.AC2889;
+    const activeMapping = { ...STANDARD_MAPPING, ...controls };
+
+    /**
+     * Rename the raw device attributes of a flat reported object to the friendly state names, mapping
+     * option values and keeping native numbers/booleans. Operates in place.
+     *
+     * @param reported a flat object of raw device attributes (the "reported" status)
+     */
+    function renameReported(reported) {
+        if (!reported) {
             return;
         }
-        const val = reported[attr];
-        delete reported[attr];
-        if (map.options && Object.prototype.hasOwnProperty.call(map.options, val)) {
-            reported[map.name] = map.options[val];
-        } else {
-            // Keep native numbers/booleans so typed states are not rejected; coerce only the rest.
-            reported[map.name] = typeof val === 'number' || typeof val === 'boolean' ? val : (val ?? '').toString();
-        }
-    });
-}
-
-/**
- * Build the raw control payload (device attribute -> raw value) from friendly state settings.
- *
- * @param settings mapping of friendly state names to desired values
- * @returns the raw payload keyed by device attribute
- */
-function buildControlPayload(settings) {
-    const payload = {};
-    Object.keys(NAME_MAPPING)
-        .filter(attr => NAME_MAPPING[attr].control)
-        .forEach(attr => {
-            const map = NAME_MAPPING[attr];
-            if (!Object.prototype.hasOwnProperty.call(settings, map.name)) {
+        Object.keys(reported).forEach(attr => {
+            const map = activeMapping[attr];
+            if (!map) {
                 return;
             }
-            const writeOptions = map.writeOptions || map.options;
-            if (writeOptions) {
-                const key = Object.keys(writeOptions).find(k => writeOptions[k] == settings[map.name]);
-                if (key === undefined) {
-                    throw new Error(
-                        `Invalid option for ${map.name}: ${settings[map.name]}. Supported only: ${JSON.stringify(writeOptions)}`,
-                    );
-                }
-                payload[attr] = map.rawType === 'number' ? Number(key) : key;
+            const val = reported[attr];
+            delete reported[attr];
+            if (map.options && Object.prototype.hasOwnProperty.call(map.options, val)) {
+                reported[map.name] = map.options[val];
             } else {
-                payload[attr] = map.rawType === 'number' ? Number(settings[map.name]) : settings[map.name];
+                // Keep native numbers/booleans so typed states are not rejected; coerce only the rest.
+                reported[map.name] = typeof val === 'number' || typeof val === 'boolean' ? val : (val ?? '').toString();
             }
         });
-    return payload;
+    }
+
+    /**
+     * Build the raw control payload (device attribute -> raw value) from friendly state settings.
+     *
+     * @param settings mapping of friendly state names to desired values
+     * @returns the raw payload keyed by device attribute
+     */
+    function buildControlPayload(settings) {
+        const payload = {};
+        Object.keys(activeMapping)
+            .filter(attr => activeMapping[attr].control)
+            .forEach(attr => {
+                const map = activeMapping[attr];
+                if (!Object.prototype.hasOwnProperty.call(settings, map.name)) {
+                    return;
+                }
+                const writeOptions = map.writeOptions || map.options;
+                if (writeOptions) {
+                    const key = Object.keys(writeOptions).find(k => writeOptions[k] == settings[map.name]);
+                    if (key === undefined) {
+                        throw new Error(
+                            `Invalid option for ${map.name}: ${settings[map.name]}. Supported only: ${JSON.stringify(writeOptions)}`,
+                        );
+                    }
+                    payload[attr] = map.rawType === 'number' ? Number(key) : key;
+                } else {
+                    payload[attr] = map.rawType === 'number' ? Number(settings[map.name]) : settings[map.name];
+                }
+            });
+        return payload;
+    }
+
+    return { mapping: activeMapping, channelOf, stateCommon, renameReported, buildControlPayload };
 }
 
-module.exports = { NAME_MAPPING, channelOf, stateCommon, renameReported, buildControlPayload };
+module.exports = {
+    createMapping,
+    STANDARD_MAPPING,
+    MODEL_MAPPING,
+    channelOf,
+    inferType,
+    stateCommon,
+};

--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -48,6 +48,31 @@ const STANDARD_MAPPING = {
     D01S0D: { name: 'serialNumber', device: true },
     D01S12: { name: 'softwareVersion', device: true },
 
+    // Read-only housekeeping/telemetry sent by new-gen CoAP devices (confirmed present in
+    // state.reported on AC3221, .claude/philips-2026.07.02.log). Legitimate diagnostics, so they get
+    // a device.* state instead of falling through to unknownStates.
+    rssi: { name: 'rssi', device: true, type: 'number', role: 'value', unit: 'dBm' },
+    free_memory: { name: 'freeMemory', device: true, type: 'number', role: 'value' },
+    // Observed only as false/-1 in the log (no string "log" content seen). otacheck/wifilog are typed
+    // boolean (coerceToType safely forces any value to boolean). blelog is kept string on purpose: its
+    // "log" name suggests it may carry text on other firmware, and coerceToType cannot coerce TO number
+    // - a number type would risk a rejected-state crash if a string ever arrives, so string is safe.
+    otacheck: { name: 'otaCheck', device: true, type: 'boolean' },
+    wifilog: { name: 'wifiLog', device: true, type: 'boolean' },
+    blelog: { name: 'bleLog', device: true, type: 'string', role: 'text' },
+
+    // Lowercase device-info aliases the new-gen CoAP frames send (classic HTTP-gen devices send the
+    // capitalized spellings above: Runtime/ProductId/DeviceId/WifiVersion/StatusType/ConnectType).
+    // Mapped to the SAME friendly names so real device info lands in device.* regardless of
+    // generation. `uptime` must keep this exact friendly name - it re-triggers the uptime -> started
+    // special case in main.js. `key` is intentionally NOT mapped here (potentially sensitive).
+    uptime: { name: 'uptime', device: true, type: 'number', role: 'value.interval', unit: 'ms' },
+    productId: { name: 'productId', device: true },
+    deviceId: { name: 'deviceId', device: true },
+    wifiVersion: { name: 'wifiVersion', device: true },
+    statusType: { name: 'statusType', device: true },
+    connectType: { name: 'connectType', device: true },
+
     // Read-only, shared across new-gen models (no per-model semantic difference).
     // CX3550 fan reports 0-3; AC3221 additionally reports 4 (speed4) and 18 (the shared max level,
     // reported for both speed5 and turbo). Cover the union so no reported speed shows as a raw number.

--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -9,6 +9,10 @@
 //   STANDARD_MAPPING          - read-only across all models (sensors, filters, device-info, error, ...)
 //   MODEL_MAPPING[model]      - ONLY the read/write controls that differ per model
 //   createMapping(model)      - activeMapping = { ...STANDARD_MAPPING, ...MODEL_MAPPING[model] }
+//
+// Authoritative reference for the new-gen D-code scheme (NEW2_* constants for CX3550/AC3221 etc.):
+//   https://github.com/kongo09/philips-airpurifier-coap
+//   https://github.com/kongo09/philips-airpurifier-coap/blob/master/custom_components/philips_airpurifier_coap/const.py
 
 /**
  * Read-only entries shared by all models: sensors, filters, device-info and error.

--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@
 // The adapter-core module gives you access to the core ioBroker functions
 // you need to create an adapter
 const utils = require('@iobroker/adapter-core');
-const { createMapping, channelOf, stateCommon } = require('./lib/mapping');
+const { createMapping, channelOf, stateCommon, modelsOwningRawKey } = require('./lib/mapping');
 const adapterName = require('./package.json').name.split('.').pop();
 
 /**
@@ -229,10 +229,22 @@ async function updateUnknownStates(status) {
         }
         if (!loggedUnknownKeys.has(rawKey)) {
             loggedUnknownKeys.add(rawKey);
-            adapter.log.info(
-                `Unknown raw device attribute "${rawKey}" (value: ${JSON.stringify(status[rawKey])}) - ` +
-                    `exposed read-only as unknownStates.${rawKey}. Please report this to the adapter developer.`,
-            );
+            // If the unmapped attribute is a known control of a DIFFERENT model, the user most likely
+            // selected the wrong device model - point them straight at the fix instead of the generic
+            // "please report" line (which is only right for a genuinely unknown attribute).
+            const owners = modelsOwningRawKey(rawKey);
+            if (owners.length) {
+                adapter.log.warn(
+                    `Device attribute "${rawKey}" is a control of model ${owners.join('/')}, but the ` +
+                        `selected model is "${adapter.config.model || 'AC2889'}". If controls are missing, ` +
+                        `select the correct device model in the adapter settings.`,
+                );
+            } else {
+                adapter.log.info(
+                    `Unknown raw device attribute "${rawKey}" (value: ${JSON.stringify(status[rawKey])}) - ` +
+                        `exposed read-only as unknownStates.${rawKey}. Please report this to the adapter developer.`,
+                );
+            }
         }
         const { type, value } = inferUnknownType(status[rawKey]);
         await setDeviceState(

--- a/main.js
+++ b/main.js
@@ -22,6 +22,10 @@ let activeMapping;
 // updateStatus() to tell genuinely unknown raw device attributes (-> unknownStates.*) apart from
 // attributes renameReported() already renamed to a friendly name (-> known, handled above).
 let knownNames;
+// Set once the device reports any of the selected model's own controls: proof that the configured
+// model matches the device dialect. Used to suppress a false "wrong model?" hint when a single
+// shared/overlapping raw register (e.g. AC3221's D03105 seen on a CX3550) is left unmapped.
+let activeModelControlSeen = false;
 // Raw attribute keys we already logged once as "unknown" this adapter run, so a device that keeps
 // reporting the same unmapped D-code does not spam the log on every status frame.
 const loggedUnknownKeys = new Set();
@@ -148,6 +152,11 @@ async function updateStatus(status) {
             continue;
         }
         writtenNames.add(item.name);
+        if (item.control) {
+            // A resolved per-model control proves the selected model matches the device: see
+            // activeModelControlSeen (gates the "wrong model?" hint in updateUnknownStates below).
+            activeModelControlSeen = true;
+        }
         const channel = channelOf(item);
 
         // The 'function' state is presented as a humidification on/off switch, not the raw text.
@@ -235,15 +244,24 @@ async function updateUnknownStates(status) {
         }
         if (!loggedUnknownKeys.has(rawKey)) {
             loggedUnknownKeys.add(rawKey);
-            // If the unmapped attribute is a known control of a DIFFERENT model, the user most likely
-            // selected the wrong device model - point them straight at the fix instead of the generic
-            // "please report" line (which is only right for a genuinely unknown attribute).
+            // If the unmapped attribute is a known control of a DIFFERENT model, the user may have
+            // selected the wrong device model - but only warn when NONE of the selected model's own
+            // controls have resolved yet. New-gen models share the D-code namespace (e.g. AC3221 and
+            // CX3550 both use D031xx), so a lone overlapping register on an otherwise-working model is
+            // just an attribute this model does not map - not a wrong-model signal - and must not
+            // nag a correctly-configured user.
             const owners = modelsOwningRawKey(rawKey);
-            if (owners.length) {
+            if (owners.length && !activeModelControlSeen) {
                 adapter.log.warn(
                     `Device attribute "${rawKey}" is a control of model ${owners.join('/')}, but the ` +
                         `selected model is "${adapter.config.model || 'AC2889'}". If controls are missing, ` +
                         `select the correct device model in the adapter settings.`,
+                );
+            } else if (owners.length) {
+                adapter.log.debug(
+                    `Raw attribute "${rawKey}" (a control of ${owners.join('/')}) is not mapped for the ` +
+                        `selected model "${adapter.config.model || 'AC2889'}"; exposed read-only as ` +
+                        `unknownStates.${rawKey}.`,
                 );
             } else {
                 adapter.log.info(

--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@
 // The adapter-core module gives you access to the core ioBroker functions
 // you need to create an adapter
 const utils = require('@iobroker/adapter-core');
-const { NAME_MAPPING, channelOf, stateCommon } = require('./lib/mapping');
+const { createMapping, channelOf, stateCommon } = require('./lib/mapping');
 const adapterName = require('./package.json').name.split('.').pop();
 
 /**
@@ -15,6 +15,9 @@ let airPurifier;
 // The selected purifier class (CoAP or HTTP) is loaded lazily in main() depending on the
 // configured protocol, so a missing optional `philips-air` dependency cannot crash CoAP users.
 let PurifierClass;
+// The active (STANDARD + model) mapping, built once in main() from adapter.config.model. Set before
+// any 'status' event can fire, so updateStatus() always sees a valid mapping.
+let activeMapping;
 
 /**
  * Starts the adapter instance
@@ -127,8 +130,8 @@ function coerceToType(value, type) {
 }
 
 async function updateStatus(status) {
-    for (const attr of Object.keys(NAME_MAPPING)) {
-        const item = NAME_MAPPING[attr];
+    for (const attr of Object.keys(activeMapping)) {
+        const item = activeMapping[attr];
         if (!Object.prototype.hasOwnProperty.call(status, item.name)) {
             continue;
         }
@@ -188,6 +191,9 @@ async function main() {
     if (!adapter.config.host) {
         return adapter.log.warn('No IP defined');
     }
+
+    // Build the active (STANDARD + model) mapping before anything can trigger a 'status' event.
+    activeMapping = createMapping(adapter.config.model).mapping;
 
     // In order to get state updates, you need to subscribe to them. The following line adds a subscription for our variable we have created above.
     adapter.subscribeStates('control.*');

--- a/main.js
+++ b/main.js
@@ -137,11 +137,17 @@ function coerceToType(value, type) {
 }
 
 async function updateStatus(status) {
+    // Several raw keys legitimately share one friendly name (e.g. the classic `Runtime` and the
+    // new-gen lowercase `uptime` alias both map to `uptime`, `dtrs`/`D03211` both to `timerMinutes`).
+    // A device only ever sends one of each pair, but both entries match `status[item.name]`, so guard
+    // against writing the same derived state twice per frame.
+    const writtenNames = new Set();
     for (const attr of Object.keys(activeMapping)) {
         const item = activeMapping[attr];
-        if (!Object.prototype.hasOwnProperty.call(status, item.name)) {
+        if (!Object.prototype.hasOwnProperty.call(status, item.name) || writtenNames.has(item.name)) {
             continue;
         }
+        writtenNames.add(item.name);
         const channel = channelOf(item);
 
         // The 'function' state is presented as a humidification on/off switch, not the raw text.

--- a/main.js
+++ b/main.js
@@ -18,6 +18,13 @@ let PurifierClass;
 // The active (STANDARD + model) mapping, built once in main() from adapter.config.model. Set before
 // any 'status' event can fire, so updateStatus() always sees a valid mapping.
 let activeMapping;
+// All friendly state names the active mapping can produce, built alongside activeMapping. Used by
+// updateStatus() to tell genuinely unknown raw device attributes (-> unknownStates.*) apart from
+// attributes renameReported() already renamed to a friendly name (-> known, handled above).
+let knownNames;
+// Raw attribute keys we already logged once as "unknown" this adapter run, so a device that keeps
+// reporting the same unmapped D-code does not spam the log on every status frame.
+const loggedUnknownKeys = new Set();
 
 /**
  * Starts the adapter instance
@@ -182,6 +189,64 @@ async function updateStatus(status) {
         const common = stateCommon(item);
         await setDeviceState(`${channel}.${item.name}`, common, coerceToType(status[item.name], common.type));
     }
+
+    await updateUnknownStates(status);
+}
+
+/**
+ * Infer an ioBroker state type from a raw JS value for a genuinely unmapped device attribute.
+ *
+ * @param value the raw value reported by the device
+ * @returns `{ type, value }` - the inferred type and the value coerced to match it
+ */
+function inferUnknownType(value) {
+    if (typeof value === 'number') {
+        return { type: 'number', value };
+    }
+    if (typeof value === 'boolean') {
+        return { type: 'boolean', value };
+    }
+    if (value !== null && typeof value === 'object') {
+        // Arrays/objects have no native ioBroker state type - stringify so the value is not lost.
+        return { type: 'string', value: JSON.stringify(value) };
+    }
+    return { type: 'string', value: value === null || value === undefined ? '' : String(value) };
+}
+
+/**
+ * Catch raw device attributes that renameReported() left untouched because no mapping entry claims
+ * them (renameReported only renames/deletes keys it recognizes, so unmapped raw keys survive into
+ * updateStatus unchanged). These are genuinely unknown attributes - write them read-only under
+ * `unknownStates.<rawKey>` and log each new raw key once so a user can report it for onboarding.
+ *
+ * @param status the (partially renamed) status object as received by updateStatus
+ */
+async function updateUnknownStates(status) {
+    for (const rawKey of Object.keys(status)) {
+        // 'key' is a potential HTTP client secret, never renamed on purpose - never surface it either.
+        if (rawKey === 'key' || knownNames.has(rawKey)) {
+            continue;
+        }
+        if (!loggedUnknownKeys.has(rawKey)) {
+            loggedUnknownKeys.add(rawKey);
+            adapter.log.info(
+                `Unknown raw device attribute "${rawKey}" (value: ${JSON.stringify(status[rawKey])}) - ` +
+                    `exposed read-only as unknownStates.${rawKey}. Please report this to the adapter developer.`,
+            );
+        }
+        const { type, value } = inferUnknownType(status[rawKey]);
+        await setDeviceState(
+            `unknownStates.${rawKey}`,
+            {
+                name: rawKey,
+                type,
+                role: type === 'boolean' ? 'indicator' : type === 'number' ? 'value' : 'text',
+                read: true,
+                write: false,
+            },
+            value,
+        );
+    }
 }
 
 async function main() {
@@ -194,6 +259,7 @@ async function main() {
 
     // Build the active (STANDARD + model) mapping before anything can trigger a 'status' event.
     activeMapping = createMapping(adapter.config.model).mapping;
+    knownNames = new Set(Object.values(activeMapping).map(item => item.name));
 
     // In order to get state updates, you need to subscribe to them. The following line adds a subscription for our variable we have created above.
     adapter.subscribeStates('control.*');

--- a/main.js
+++ b/main.js
@@ -104,6 +104,28 @@ async function setDeviceState(id, common, value) {
     await adapter.setStateAsync(id, value, true);
 }
 
+/**
+ * Coerce a value to the state's declared type so js-controller never rejects a typed state when a
+ * device reports a value outside our known option set (e.g. an unmapped numeric fan/purifier mode
+ * for a string-typed control). Only string and boolean are forced; numbers pass through unchanged.
+ *
+ * @param value the value about to be written
+ * @param type the ioBroker `common.type` of the target state
+ * @returns the value coerced to match `type`
+ */
+function coerceToType(value, type) {
+    if (value === null || value === undefined) {
+        return value;
+    }
+    if (type === 'string' && typeof value !== 'string') {
+        return String(value);
+    }
+    if (type === 'boolean' && typeof value !== 'boolean') {
+        return Boolean(value);
+    }
+    return value;
+}
+
 async function updateStatus(status) {
     for (const attr of Object.keys(NAME_MAPPING)) {
         const item = NAME_MAPPING[attr];
@@ -154,7 +176,8 @@ async function updateStatus(status) {
             continue;
         }
 
-        await setDeviceState(`${channel}.${item.name}`, stateCommon(item), status[item.name]);
+        const common = stateCommon(item);
+        await setDeviceState(`${channel}.${item.name}`, common, coerceToType(status[item.name], common.type));
     }
 }
 

--- a/test/testCoap.js
+++ b/test/testCoap.js
@@ -1,6 +1,7 @@
 const { expect } = require('chai');
 const coap = require('coap');
 const AirPurifier = require('../lib/coap');
+const { createMapping } = require('../lib/mapping');
 
 // Build an instance without running the constructor (which would start networking).
 function makeInstance(clientKey = 'AABBCCDD') {
@@ -8,6 +9,11 @@ function makeInstance(clientKey = 'AABBCCDD') {
     inst.clientKey = clientKey;
     inst.deviceIp = '127.0.0.1';
     inst.emit = () => {};
+    // The constructor normally builds these from createMapping(this.adapter.config.model); tests that
+    // bypass the constructor need them set explicitly (default to the classic AC2889 mapping).
+    const m = createMapping('AC2889');
+    inst.renameReported = m.renameReported;
+    inst.buildControlPayload = m.buildControlPayload;
     return inst;
 }
 

--- a/test/testCoap.js
+++ b/test/testCoap.js
@@ -45,6 +45,14 @@ describe('coap - encryption', () => {
         expect(JSON.parse(decrypted)).to.deep.equal({ a: 1 });
     });
 
+    it('decryptPayload rejects a non-hex / too-short payload with a clear error', () => {
+        const inst = makeInstance();
+        // Garbage that is not hex, and a hex string shorter than counter+body+digest (72 chars): both
+        // must be rejected up front with a clear error instead of being fed into the cipher.
+        expect(() => inst.decryptPayload(Buffer.from('not-hex-garbage'))).to.throw(/Unexpected encrypted payload/i);
+        expect(() => inst.decryptPayload(Buffer.from('AABB'))).to.throw(/Unexpected encrypted payload/i);
+    });
+
     it('updateClientKey increments the key as an 8-char uppercase hex counter', () => {
         const inst = makeInstance('0000000F');
         inst.updateClientKey();

--- a/test/testMapping.js
+++ b/test/testMapping.js
@@ -179,6 +179,210 @@ describe('mapping - CX3550', () => {
     });
 });
 
+describe('mapping - CX7550', () => {
+    const { renameReported, buildControlPayload, mapping } = createMapping('CX7550');
+
+    it('maps the full live status frame of a CX7550/01 (GitHub #372)', () => {
+        const reported = {
+            D01S03: 'Turmventilator',
+            D01S04: 'Babel',
+            D01S05: 'CX7550/01',
+            D01S12: '0.2.9',
+            D03102: 1,
+            D03104: 100,
+            D03105: 123,
+            D0310C: 82,
+            D0310D: 82,
+            D0320F: 0,
+            D03110: 0,
+            D03211: 0,
+            D03224: 240,
+            D0312A: 7,
+            D0312B: 7,
+            D03130: 100,
+        };
+        renameReported(reported);
+        expect(reported).to.deep.equal({
+            name: 'Turmventilator',
+            platform: 'Babel',
+            modelId: 'CX7550/01',
+            softwareVersion: '0.2.9',
+            power: true,
+            temperatureColorDisplay: true,
+            displayBrightness: 'high',
+            mode: 'speed12',
+            fanSpeedReported: 'speed12',
+            oscillation: false,
+            timerCode: 'off',
+            timerMinutes: 0,
+            temperature: 24,
+            persistentDisplay: 'fanSpeed',
+            persistentDisplayReported: 'fanSpeed',
+            beep: true,
+        });
+    });
+
+    it('covers all twelve speeds plus AutoAdapt, sleep and natural breeze', () => {
+        const rawToFriendly = {
+            0: 'auto',
+            1: 'speed1',
+            2: 'speed2',
+            3: 'speed3',
+            4: 'speed4',
+            5: 'speed5',
+            6: 'speed6',
+            7: 'speed7',
+            8: 'speed8',
+            9: 'speed9',
+            10: 'speed10',
+            17: 'sleep',
+            81: 'speed11',
+            82: 'speed12',
+            '-126': 'naturalBreeze',
+        };
+        Object.entries(rawToFriendly).forEach(([raw, friendly]) => {
+            const reported = { D0310C: Number(raw) };
+            renameReported(reported);
+            expect(reported.mode).to.equal(friendly);
+            // Round trip: the friendly value must resolve back to the very same raw code.
+            expect(buildControlPayload({ mode: friendly })).to.deep.equal({ D0310C: Number(raw) });
+        });
+    });
+
+    it('overrides the shared reported-speed entry so speeds 5-12 do not stay raw numbers', () => {
+        [5, 6, 7, 8, 9, 10].forEach(raw => {
+            const reported = { D0310D: raw };
+            renameReported(reported);
+            expect(reported.fanSpeedReported).to.equal(`speed${raw}`);
+        });
+        const high = { D0310D: 81 };
+        renameReported(high);
+        expect(high.fanSpeedReported).to.equal('speed11');
+        expect(mapping.D0310D.control).to.be.undefined;
+    });
+
+    it('uses raw 80 for oscillation on both read and write (not the CX3550 23040/90 pair)', () => {
+        const reported = { D0320F: 80 };
+        renameReported(reported);
+        expect(reported.oscillation).to.be.true;
+        expect(mapping.D0320F.writeOptions).to.be.undefined;
+        expect(buildControlPayload({ oscillation: true })).to.deep.equal({ D0320F: 80 });
+        expect(buildControlPayload({ oscillation: false })).to.deep.equal({ D0320F: 0 });
+    });
+
+    it('exposes the timer as a writable control with friendly durations', () => {
+        expect(channelOf(mapping.D03110)).to.equal('control');
+        const rawToFriendly = {
+            0: 'off',
+            2: '1h',
+            3: '2h',
+            4: '3h',
+            5: '4h',
+            6: '5h',
+            7: '6h',
+            8: '7h',
+            9: '8h',
+            10: '9h',
+            11: '10h',
+            12: '11h',
+            13: '12h',
+        };
+        Object.entries(rawToFriendly).forEach(([raw, friendly]) => {
+            const reported = { D03110: Number(raw) };
+            renameReported(reported);
+            expect(reported.timerCode).to.equal(friendly);
+            expect(buildControlPayload({ timerCode: friendly })).to.deep.equal({ D03110: Number(raw) });
+        });
+    });
+
+    it('scales the room temperature register from tenths of a degree', () => {
+        [
+            [240, 24],
+            [255, 25.5],
+            [0, 0],
+        ].forEach(([raw, expected]) => {
+            const reported = { D03224: raw };
+            renameReported(reported);
+            expect(reported.temperature).to.equal(expected);
+        });
+        // Reuses the friendly name of the classic `temp` key - a device sends only one of the two.
+        expect(mapping.D03224.name).to.equal(STANDARD_MAPPING.temp.name);
+        expect(mapping.D03224.control).to.be.undefined;
+    });
+
+    it('maps the display group this model adds on top of the CX3550 controls', () => {
+        expect(buildControlPayload({ displayBrightness: 'low' })).to.deep.equal({ D03105: 115 });
+        expect(buildControlPayload({ temperatureColorDisplay: false })).to.deep.equal({ D03104: 0 });
+        expect(buildControlPayload({ persistentDisplay: 'temperature' })).to.deep.equal({ D0312A: 5 });
+        // The echoed setting is status only, never writable.
+        expect(channelOf(mapping.D0312B)).to.equal('status');
+        expect(buildControlPayload({ persistentDisplayReported: 'temperature' })).to.deep.equal({});
+    });
+
+    it('leaves the still-undecoded registers unmapped so they surface as unknownStates', () => {
+        ['D0310A', 'D03133', 'D03240', 'D0313B'].forEach(attr => {
+            expect(mapping).to.not.have.property(attr);
+        });
+        const reported = { D03133: 1, D0313B: 20 };
+        renameReported(reported);
+        expect(reported).to.deep.equal({ D03133: 1, D0313B: 20 });
+    });
+
+    it('places the writable states under control and the reported ones under status', () => {
+        const expectedPaths = {
+            D03102: 'control.power',
+            D0310C: 'control.mode',
+            D0320F: 'control.oscillation',
+            D03110: 'control.timerCode',
+            D03130: 'control.beep',
+            D03105: 'control.displayBrightness',
+            D03104: 'control.temperatureColorDisplay',
+            D0312A: 'control.persistentDisplay',
+            D0310D: 'status.fanSpeedReported',
+            D0312B: 'status.persistentDisplayReported',
+            D03211: 'status.timerMinutes',
+            D03224: 'status.temperature',
+        };
+
+        Object.entries(expectedPaths).forEach(([attr, path]) => {
+            const item = mapping[attr];
+            expect(`${channelOf(item)}.${item.name}`).to.equal(path);
+        });
+    });
+
+    it('does not leak its raw values into the CX3550 table', () => {
+        // Both fans share the D-code namespace with different values - the whole point of the
+        // per-model table. Guard the pairs that actually differ.
+        const cx3550 = createMapping('CX3550');
+        expect(cx3550.buildControlPayload({ oscillation: true })).to.deep.equal({ D0320F: 90 });
+        expect(cx3550.mapping.D0310C.options[82]).to.be.undefined;
+        expect(cx3550.mapping.D03110.control).to.be.undefined;
+        expect(cx3550.mapping.D03105.control).to.be.undefined;
+    });
+});
+
+describe('mapping - boolean controls written as text', () => {
+    // ioBroker states can be written as the string "true"/"false" (script, VIS widget, REST call).
+    // Loose equality does not save us here - `false == 'false'` is false - so without normalization
+    // the write was rejected with "Invalid option" and the command never reached the device.
+    it('accepts "true"/"false" for boolean controls of every model', () => {
+        expect(createMapping('CX7550').buildControlPayload({ power: 'false' })).to.deep.equal({ D03102: 0 });
+        expect(createMapping('CX7550').buildControlPayload({ power: 'true' })).to.deep.equal({ D03102: 1 });
+        expect(createMapping('CX3550').buildControlPayload({ oscillation: 'false' })).to.deep.equal({ D0320F: 0 });
+        expect(createMapping('AC2889').buildControlPayload({ childLock: 'true' })).to.deep.equal({ cl: '1' });
+    });
+
+    it('still rejects a value that is not a valid option', () => {
+        expect(() => createMapping('CX7550').buildControlPayload({ power: 'yes' })).to.throw(
+            /Invalid option for power/,
+        );
+    });
+
+    it('does not touch non-boolean option values that happen to be strings', () => {
+        expect(createMapping('CX7550').buildControlPayload({ mode: 'sleep' })).to.deep.equal({ D0310C: 17 });
+    });
+});
+
 describe('mapping - AC3221', () => {
     const { renameReported, mapping } = createMapping('AC3221');
 
@@ -325,9 +529,9 @@ describe('mapping - modelsOwningRawKey (wrong-model hint)', () => {
     });
 
     it('names every model that owns a shared new-gen control key', () => {
-        // D03102 (power) is a control of both new-gen tables - a Generic/AC2889 user seeing it should
-        // be pointed at both candidates.
-        expect(modelsOwningRawKey('D03102')).to.have.members(['CX3550', 'AC3221']);
+        // D03102 (power) is a control of every new-gen table - a Generic/AC2889 user seeing it should
+        // be pointed at all candidates.
+        expect(modelsOwningRawKey('D03102')).to.have.members(['CX3550', 'CX7550', 'AC3221']);
     });
 
     it('returns no owner for a genuinely unknown raw attribute', () => {
@@ -343,8 +547,8 @@ describe('mapping - modelsOwningRawKey (wrong-model hint)', () => {
     it('does not treat a model read-only register as owned (control-only)', () => {
         // D0310A/D03105 are exposed read-only in the CX3550 table, not as controls, so a correctly
         // configured fan reporting them must never be nagged with a wrong-model hint. D03105 is still
-        // owned by AC3221 (there it IS a control), but no longer by CX3550.
+        // owned by AC3221 and CX7550 (there it IS a control), but no longer by CX3550.
         expect(modelsOwningRawKey('D0310A')).to.deep.equal([]);
-        expect(modelsOwningRawKey('D03105')).to.deep.equal(['AC3221']);
+        expect(modelsOwningRawKey('D03105')).to.have.members(['CX7550', 'AC3221']);
     });
 });

--- a/test/testMapping.js
+++ b/test/testMapping.js
@@ -1,7 +1,9 @@
 const { expect } = require('chai');
-const { NAME_MAPPING, channelOf, renameReported, buildControlPayload } = require('../lib/mapping');
+const { createMapping, channelOf, STANDARD_MAPPING, MODEL_MAPPING } = require('../lib/mapping');
 
-describe('mapping - renameReported', () => {
+describe('mapping - renameReported (AC2889)', () => {
+    const { renameReported } = createMapping('AC2889');
+
     it('renames attributes, maps options and keeps native types', () => {
         const reported = { pm25: 7, pwr: '1', cl: 0, mode: 'M', om: 'a', name: 'Schlafzimmer' };
         renameReported(reported);
@@ -30,55 +32,11 @@ describe('mapping - renameReported', () => {
         expect(r).to.deep.equal({ somethingUnknown: 5 });
         expect(() => renameReported(undefined)).to.not.throw();
     });
-
-    it('maps CX3550 reported values and keeps timer read-only', () => {
-        const reported = {
-            D01S03: 'Ventilator',
-            D01S05: 'CX3550/01',
-            D03102: 1,
-            D03105: 100,
-            D0310C: -126,
-            D0310D: 3,
-            D0320F: 23040,
-            D03110: '2h',
-            D03211: 120,
-            D03130: 100,
-        };
-        renameReported(reported);
-        expect(reported).to.deep.equal({
-            name: 'Ventilator',
-            modelId: 'CX3550/01',
-            D03105: 100,
-            cxPower: true,
-            cxFanMode: 'naturalBreeze',
-            cxFanSpeedReported: 'speed3',
-            cxOscillation: true,
-            cxTimerCode: '2h',
-            cxTimerMinutes: 120,
-            cxBeep: true,
-        });
-    });
-
-    it('maps CX3550 control/status values as soon as they are reported', () => {
-        const reported = {
-            D03102: 1,
-            D0310C: 17,
-            D0310D: 2,
-            D0320F: 23040,
-            D03130: 100,
-        };
-        renameReported(reported);
-        expect(reported).to.deep.equal({
-            cxPower: true,
-            cxFanMode: 'sleep',
-            cxFanSpeedReported: 'speed2',
-            cxOscillation: true,
-            cxBeep: true,
-        });
-    });
 });
 
-describe('mapping - buildControlPayload', () => {
+describe('mapping - buildControlPayload (AC2889)', () => {
+    const { buildControlPayload } = createMapping('AC2889');
+
     it('resolves option values back to their raw device codes', () => {
         expect(buildControlPayload({ power: true })).to.deep.equal({ pwr: '1' });
         expect(buildControlPayload({ fanSpeed: 'auto', mode: 'manual' })).to.deep.equal({ om: 'a', mode: 'M' });
@@ -97,16 +55,64 @@ describe('mapping - buildControlPayload', () => {
     it('throws for an invalid option value', () => {
         expect(() => buildControlPayload({ fanSpeed: 'hurricane' })).to.throw(/Invalid option for fanSpeed/);
     });
+});
 
-    it('builds numeric CX3550 control payloads without timer controls', () => {
+describe('mapping - CX3550', () => {
+    const { renameReported, buildControlPayload, mapping } = createMapping('CX3550');
+
+    it('maps CX3550 reported values with generic names and keeps timer read-only', () => {
+        const reported = {
+            D01S03: 'Ventilator',
+            D01S05: 'CX3550/01',
+            D03102: 1,
+            D0310C: -126,
+            D0310D: 3,
+            D0320F: 23040,
+            D03110: '2h',
+            D03211: 120,
+            D03130: 100,
+        };
+        renameReported(reported);
+        expect(reported).to.deep.equal({
+            name: 'Ventilator',
+            modelId: 'CX3550/01',
+            power: true,
+            mode: 'naturalBreeze',
+            fanSpeedReported: 'speed3',
+            oscillation: true,
+            timerCode: '2h',
+            timerMinutes: 120,
+            beep: true,
+        });
+    });
+
+    it('maps CX3550 control/status values as soon as they are reported', () => {
+        const reported = {
+            D03102: 1,
+            D0310C: 17,
+            D0310D: 2,
+            D0320F: 23040,
+            D03130: 100,
+        };
+        renameReported(reported);
+        expect(reported).to.deep.equal({
+            power: true,
+            mode: 'sleep',
+            fanSpeedReported: 'speed2',
+            oscillation: true,
+            beep: true,
+        });
+    });
+
+    it('builds numeric CX3550 control payloads without timer controls, oscillation write uses raw 90', () => {
         expect(
             buildControlPayload({
-                cxPower: true,
-                cxFanMode: 'sleep',
-                cxOscillation: true,
-                cxBeep: false,
-                cxTimerCode: '2h',
-                cxTimerMinutes: 120,
+                power: true,
+                mode: 'sleep',
+                oscillation: true,
+                beep: false,
+                timerCode: '2h',
+                timerMinutes: 120,
             }),
         ).to.deep.equal({
             D03102: 1,
@@ -115,33 +121,124 @@ describe('mapping - buildControlPayload', () => {
             D03130: 0,
         });
     });
-});
 
-describe('mapping - NAME_MAPPING', () => {
-    it('is a non-empty shared object used by both protocols', () => {
-        expect(NAME_MAPPING).to.be.an('object');
-        expect(Object.keys(NAME_MAPPING).length).to.be.greaterThan(30);
-        expect(NAME_MAPPING.err.name).to.equal('error');
-    });
-
-    it('places CX3550 writable states under control and reported speed under status', () => {
+    it('places CX3550 writable states under control and reported speed/timers under status', () => {
         const expectedPaths = {
-            D03102: 'control.cxPower',
-            D0310C: 'control.cxFanMode',
-            D0320F: 'control.cxOscillation',
-            D03130: 'control.cxBeep',
-            D0310D: 'status.cxFanSpeedReported',
-            D03110: 'status.cxTimerCode',
-            D03211: 'status.cxTimerMinutes',
+            D03102: 'control.power',
+            D0310C: 'control.mode',
+            D0320F: 'control.oscillation',
+            D03130: 'control.beep',
+            D0310D: 'status.fanSpeedReported',
+            D03110: 'status.timerCode',
+            D03211: 'status.timerMinutes',
         };
 
         Object.entries(expectedPaths).forEach(([attr, path]) => {
-            const item = NAME_MAPPING[attr];
+            const item = mapping[attr];
             expect(`${channelOf(item)}.${item.name}`).to.equal(path);
         });
     });
 
-    it('does not expose D03105 as CX fan percent or a control state', () => {
-        expect(NAME_MAPPING).to.not.have.property('D03105');
+    it('carries verbatim metadata required for correct raw en/decoding (Datentreue-Checkliste)', () => {
+        expect(mapping.D03102).to.include({ control: true, rawType: 'number' });
+        expect(mapping.D03102.options).to.deep.equal({ 1: true, 0: false });
+
+        expect(mapping.D0310C).to.include({ control: true, rawType: 'number', role: 'level.mode' });
+        expect(mapping.D0310C.options).to.deep.equal({
+            1: 'speed1',
+            2: 'speed2',
+            3: 'speed3',
+            17: 'sleep',
+            '-126': 'naturalBreeze',
+        });
+
+        expect(mapping.D0320F).to.include({ control: true, rawType: 'number' });
+        expect(mapping.D0320F.options).to.deep.equal({ 23040: true, 0: false });
+        expect(mapping.D0320F.writeOptions).to.deep.equal({ 90: true, 0: false });
+
+        expect(mapping.D03130).to.include({ control: true, rawType: 'number' });
+        expect(mapping.D03130.options).to.deep.equal({ 100: true, 0: false });
+
+        expect(mapping.D03110.type).to.equal('string');
+        expect(mapping.D03110.control).to.be.undefined;
+    });
+});
+
+describe('mapping - AC3221', () => {
+    const { renameReported, mapping } = createMapping('AC3221');
+
+    it('D0310C covers all 10 emitted values with the corrected labels (no fall-through)', () => {
+        const rawToFriendly = {
+            '-16': 'off',
+            0: 'auto',
+            1: 'speed1',
+            2: 'speed2',
+            3: 'speed3',
+            4: 'speed4',
+            5: 'speed5',
+            17: 'sleep',
+            18: 'turbo',
+            19: 'medium',
+        };
+        Object.entries(rawToFriendly).forEach(([raw, friendly]) => {
+            const reported = { D0310C: Number(raw) };
+            renameReported(reported);
+            expect(reported.mode).to.equal(friendly);
+        });
+    });
+
+    it('maps the corrected D03105 display brightness options', () => {
+        const reported = { D03105: 101 };
+        renameReported(reported);
+        expect(reported.displayBrightness).to.equal('auto');
+    });
+
+    it('keeps D03110 (timer) read-only with an explicit string type', () => {
+        expect(mapping.D03110.type).to.equal('string');
+        expect(mapping.D03110.control).to.be.undefined;
+    });
+});
+
+describe('mapping - Generic', () => {
+    it('has no controls, so unmapped attributes stay untouched (handled upstream as unknownStates)', () => {
+        const { mapping, renameReported } = createMapping('Generic');
+        expect(MODEL_MAPPING.Generic).to.deep.equal({});
+        expect(Object.values(mapping).some(item => item.control)).to.be.false;
+
+        const reported = { someUnmappedDCode: 42 };
+        renameReported(reported);
+        expect(reported).to.deep.equal({ someUnmappedDCode: 42 });
+    });
+});
+
+describe('mapping - createMapping fallback', () => {
+    it('falls back to AC2889 controls for an undefined model', () => {
+        const { mapping } = createMapping(undefined);
+        expect(mapping.pwr).to.deep.equal(MODEL_MAPPING.AC2889.pwr);
+    });
+
+    it('falls back to AC2889 controls for an unknown/mistyped model string', () => {
+        const { mapping } = createMapping('AC2889-typo');
+        expect(mapping.pwr).to.deep.equal(MODEL_MAPPING.AC2889.pwr);
+        expect(mapping.D03102).to.be.undefined;
+    });
+});
+
+describe('mapping - STANDARD_MAPPING', () => {
+    it('is a non-empty shared object used by all models', () => {
+        expect(STANDARD_MAPPING).to.be.an('object');
+        expect(Object.keys(STANDARD_MAPPING).length).to.be.greaterThan(15);
+        expect(STANDARD_MAPPING.err.name).to.equal('error');
+    });
+
+    it('does not contain the model-specific control D-codes (only one model is ever active)', () => {
+        ['D03102', 'D0310C', 'D03130'].forEach(attr => {
+            expect(STANDARD_MAPPING).to.not.have.property(attr);
+        });
+    });
+
+    it('does not expose D03105 as a control state for AC2889/CX3550', () => {
+        const { mapping } = createMapping('AC2889');
+        expect(mapping).to.not.have.property('D03105');
     });
 });

--- a/test/testMapping.js
+++ b/test/testMapping.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai');
-const { createMapping, channelOf, STANDARD_MAPPING, MODEL_MAPPING } = require('../lib/mapping');
+const { createMapping, channelOf, STANDARD_MAPPING, MODEL_MAPPING, modelsOwningRawKey } = require('../lib/mapping');
 
 describe('mapping - renameReported (AC2889)', () => {
     const { renameReported } = createMapping('AC2889');
@@ -297,5 +297,27 @@ describe('mapping - unknownStates classification (Umbau-Schritt 4, Part B)', () 
         ['rssi', 'freeMemory', 'otaCheck', 'wifiLog', 'bleLog', 'uptime', 'productId', 'deviceId'].forEach(name => {
             expect(knownNames.has(name)).to.be.true;
         });
+    });
+});
+
+describe('mapping - modelsOwningRawKey (wrong-model hint)', () => {
+    it('names the model that owns a classic control key', () => {
+        expect(modelsOwningRawKey('pwr')).to.deep.equal(['AC2889']);
+    });
+
+    it('names every model that owns a shared new-gen control key', () => {
+        // D03102 (power) is a control of both new-gen tables - a Generic/AC2889 user seeing it should
+        // be pointed at both candidates.
+        expect(modelsOwningRawKey('D03102')).to.have.members(['CX3550', 'AC3221']);
+    });
+
+    it('returns no owner for a genuinely unknown raw attribute', () => {
+        expect(modelsOwningRawKey('D09999')).to.deep.equal([]);
+    });
+
+    it('does not treat read-only STANDARD keys as owned by a model', () => {
+        // Shared read-only attributes (e.g. the D0310D reported speed) live in STANDARD, not in any
+        // model table, so they must never trigger a wrong-model hint.
+        expect(modelsOwningRawKey('D0310D')).to.deep.equal([]);
     });
 });

--- a/test/testMapping.js
+++ b/test/testMapping.js
@@ -162,6 +162,21 @@ describe('mapping - CX3550', () => {
         expect(mapping.D03110.type).to.equal('string');
         expect(mapping.D03110.control).to.be.undefined;
     });
+
+    it('exposes the fan-only registers D0310A/D03105 read-only under device.* (no invented heater/light semantics)', () => {
+        // The CX3550 fan reports D0310A (=1) and D03105 (=100) but has neither a heater nor a display,
+        // so they are exposed read-only under their raw code - never mislabelled as circulation/backlight.
+        ['D0310A', 'D03105'].forEach(attr => {
+            expect(mapping[attr]).to.include({ device: true, type: 'number' });
+            expect(mapping[attr].control).to.be.undefined;
+            expect(channelOf(mapping[attr])).to.equal('device');
+        });
+        const reported = { D0310A: 1, D03105: 100 };
+        renameReported(reported);
+        // Renamed to themselves (raw code = friendly name), native number kept - so they land in a
+        // known device.* state instead of unknownStates.
+        expect(reported).to.deep.equal({ D0310A: 1, D03105: 100 });
+    });
 });
 
 describe('mapping - AC3221', () => {
@@ -238,8 +253,12 @@ describe('mapping - STANDARD_MAPPING', () => {
     });
 
     it('does not expose D03105 as a control state for AC2889/CX3550', () => {
-        const { mapping } = createMapping('AC2889');
-        expect(mapping).to.not.have.property('D03105');
+        // AC2889 has no D03105 at all; CX3550 exposes it read-only (device.*), never as a control.
+        expect(createMapping('AC2889').mapping).to.not.have.property('D03105');
+        const cx = createMapping('CX3550').mapping;
+        expect(cx).to.have.property('D03105');
+        expect(cx.D03105.control).to.be.undefined;
+        expect(cx.D03105.device).to.be.true;
     });
 
     it('maps diagnostic/telemetry keys as read-only device.* states (Umbau-Schritt 4, Part A)', () => {
@@ -319,5 +338,13 @@ describe('mapping - modelsOwningRawKey (wrong-model hint)', () => {
         // Shared read-only attributes (e.g. the D0310D reported speed) live in STANDARD, not in any
         // model table, so they must never trigger a wrong-model hint.
         expect(modelsOwningRawKey('D0310D')).to.deep.equal([]);
+    });
+
+    it('does not treat a model read-only register as owned (control-only)', () => {
+        // D0310A/D03105 are exposed read-only in the CX3550 table, not as controls, so a correctly
+        // configured fan reporting them must never be nagged with a wrong-model hint. D03105 is still
+        // owned by AC3221 (there it IS a control), but no longer by CX3550.
+        expect(modelsOwningRawKey('D0310A')).to.deep.equal([]);
+        expect(modelsOwningRawKey('D03105')).to.deep.equal(['AC3221']);
     });
 });

--- a/test/testMapping.js
+++ b/test/testMapping.js
@@ -241,4 +241,61 @@ describe('mapping - STANDARD_MAPPING', () => {
         const { mapping } = createMapping('AC2889');
         expect(mapping).to.not.have.property('D03105');
     });
+
+    it('maps diagnostic/telemetry keys as read-only device.* states (Umbau-Schritt 4, Part A)', () => {
+        const diagnosticKeys = ['rssi', 'free_memory', 'otacheck', 'wifilog', 'blelog'];
+        diagnosticKeys.forEach(attr => {
+            expect(STANDARD_MAPPING).to.have.property(attr);
+            const item = STANDARD_MAPPING[attr];
+            expect(item.device).to.be.true;
+            expect(item.control).to.be.undefined;
+            expect(channelOf(item)).to.equal('device');
+        });
+        expect(STANDARD_MAPPING.rssi.type).to.equal('number');
+        expect(STANDARD_MAPPING.free_memory.type).to.equal('number');
+        expect(STANDARD_MAPPING.otacheck.type).to.equal('boolean');
+        expect(STANDARD_MAPPING.wifilog.type).to.equal('boolean');
+        // blelog is typed string, not number: coerceToType cannot coerce TO number, so a numeric type
+        // would risk a rejected-state crash if firmware ever sends log text; string is always safe.
+        expect(STANDARD_MAPPING.blelog.type).to.equal('string');
+    });
+
+    it('maps the lowercase new-gen device-info aliases to the same friendly names as the classic keys', () => {
+        expect(STANDARD_MAPPING.uptime.name).to.equal('uptime');
+        expect(STANDARD_MAPPING.uptime.name).to.equal(STANDARD_MAPPING.Runtime.name);
+        expect(STANDARD_MAPPING.productId.name).to.equal(STANDARD_MAPPING.ProductId.name);
+        expect(STANDARD_MAPPING.deviceId.name).to.equal(STANDARD_MAPPING.DeviceId.name);
+        expect(STANDARD_MAPPING.wifiVersion.name).to.equal(STANDARD_MAPPING.WifiVersion.name);
+        expect(STANDARD_MAPPING.statusType.name).to.equal(STANDARD_MAPPING.StatusType.name);
+        expect(STANDARD_MAPPING.connectType.name).to.equal(STANDARD_MAPPING.ConnectType.name);
+        // 'key' is intentionally not mapped (potentially sensitive).
+        expect(STANDARD_MAPPING).to.not.have.property('key');
+    });
+
+    it('renames a lowercase uptime frame the same way as the classic Runtime key', () => {
+        const { renameReported } = createMapping('AC3221');
+        const reported = { uptime: 12345 };
+        renameReported(reported);
+        expect(reported).to.deep.equal({ uptime: 12345 });
+    });
+});
+
+describe('mapping - unknownStates classification (Umbau-Schritt 4, Part B)', () => {
+    // main.js builds `knownNames = new Set(Object.values(activeMapping).map(m => m.name))` once and
+    // routes any status key NOT in that set (and not 'key') to unknownStates. Exercise the same
+    // classification here at the mapping level, since a full adapter run is out of scope for this
+    // unit test file.
+    it('excludes an invented/unmapped raw attribute from the known friendly names', () => {
+        const { mapping } = createMapping('AC3221');
+        const knownNames = new Set(Object.values(mapping).map(item => item.name));
+        expect(knownNames.has('someTotallyInventedRawDCode')).to.be.false;
+    });
+
+    it('includes the new diagnostic/device-info friendly names in the known set (so they do NOT route to unknownStates)', () => {
+        const { mapping } = createMapping('AC3221');
+        const knownNames = new Set(Object.values(mapping).map(item => item.name));
+        ['rssi', 'freeMemory', 'otaCheck', 'wifiLog', 'bleLog', 'uptime', 'productId', 'deviceId'].forEach(name => {
+            expect(knownNames.has(name)).to.be.true;
+        });
+    });
 });


### PR DESCRIPTION
### What & why

The CX3550/01 fan support merged in v1.6.1 introduced `cx*`-prefixed state IDs
in a single flat mapping. That doesn't scale: different device generations reuse
the same D-codes with different meanings (e.g. `D0310C` = ~5 speeds + Turbo on
new-gen purifiers vs. 3 speeds + naturalBreeze on the fan), so a flat table
can't tell them apart.

This PR reworks the mapping into a **layered, model-based** design and adds a
**device-model selector** in the admin config, plus support for the **AC3221**
next-generation purifier.

### Changes

- **Layered mapping** (`lib/mapping.js`): a shared `STANDARD_MAPPING`
  (all read-only sensors, status, device info, filters, `error`) plus a
  per-model `MODEL_MAPPING[model]` holding only the writable controls that
  differ per device. Only one model table is active at a time, so control
  states get clean generic names (`power`, `mode`, `fanSpeed`, `oscillation`,
  `beep`, …) with no prefix and no collisions.
- **Device-model dropdown** (admin): pick **AC2889 / AC3221 / CX3550 / Generic**.
  Default **AC2889** to protect the classic base install from losing controls on
  a config re-save. Translated in all 11 languages.
- **AC3221** next-generation purifier support: power, fan speed/mode, display
  brightness, light mode, child lock, beep and more (D-code semantics confirmed
  from a full device re-test log).
- **Wrong-model warning**: when an unmapped attribute is actually a control of a
  *different* model, the adapter logs a targeted hint instead of a generic
  "unknown attribute" line — helps users spot a mis-set model.
- **Device diagnostics + `unknownStates`**: Wi-Fi signal, free memory etc. are
  surfaced under `device.*`; unrecognised attributes are collected in an
  `unknownStates.*` channel (and logged), so new/unknown devices can be
  onboarded from real data. Two healthy AC2889 attributes found this way
  (`range`, `aqit_ext`) are now mapped read-only as `device.range` /
  `device.airQualityThresholdExt`.
- Crash fix: reported values are coerced to the state's declared type before
  writing, preventing a crash when a device reports a value outside a control's
  option set (`... has to be type "string" but received type "number"`).
- Timer states (`D03110` / `D03211`) stay strictly **read-only** on CX3550 and
  AC3221 — new-gen firmware turns the device **off** on a local timer write.

### ⚠️ Breaking (CX3550 only)

All CX3550 state IDs starting with `cx` were renamed to generic names
(e.g. `fanMode` instead of `cxFanMode`). CX3550 users should **select their
model once** in the settings; the old `cx*` objects can be deleted manually.
CX3550 support is only days old, so few users are affected.

### Testing

- Live-tested on an **AC2889** (dev-server soak run, no disconnects / reconnects
  / crashes; all classic state IDs stable; diagnostics land under `device.*`).
- AC3221 D-code semantics derived from a full device re-test log.
- `npm test` — 30 tests green, `npm run lint` clean.

### Notes for the maintainer

No version bump and no `io-package.json` `news` entry — left for the
`chore: release` commit, as with 1.6.1. A `### **WORK IN PROGRESS**` block is
already in the README changelog.