### PR TITLE
docs: document the twelve unmapped raw attributes of the CX7550

### DIFF
--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -56,6 +56,12 @@ const STANDARD_MAPPING = {
     D01S0D: { name: 'serialNumber', device: true },
     D01S12: { name: 'softwareVersion', device: true },
 
+    // The same device-info block also carries eight numeric keys that stay constant no matter what is
+    // switched on the device (CX7550/01 test report, GitHub #372): D01102=2, D01107=0, D01108=3,
+    // D01109=3, D0110A=0, D0110C=1, D0110F=3, D01213=0. Without an observable change their meaning
+    // cannot be derived, so they are left unmapped and surface as unknownStates.* - an invented name
+    // would be worse than the raw code.
+
     // Read-only housekeeping/telemetry sent by new-gen CoAP devices (confirmed present in
     // state.reported on AC3221, .claude/philips-2026.07.02.log). Legitimate diagnostics, so they get
     // a device.* state instead of falling through to unknownStates.
@@ -295,6 +301,9 @@ const MODEL_MAPPING = {
         // Also reported every frame, meaning unknown: D0310A=1, D03133=1, D03240=0, D0313B=20.
         // Left unmapped on purpose so they surface under unknownStates.* instead of getting invented
         // semantics. None of them is another model's control, so they cannot trip the wrong-model hint.
+        // Confirmed by the CX7550/01 test report (GitHub #372): together with the eight D011xx/D01213
+        // device-info keys these are all twelve unknownStates.* the fan produces, and none of them
+        // changed during a full run through every function of the remote and the adapter.
     },
 
     // AC3221 new-gen air purifier.


### PR DESCRIPTION
Comment-only change: records why the CX7550's twelve unknownStates.* keys stay unmapped - none of
them changed during the full test run in #372, so their meaning cannot be derived.