### PR TITLE
feat(AC3221): expose sensor readings and filter life

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ More details are documented in [docs/CX7550.md](docs/CX7550.md).
 ### **WORK IN PROGRESS**
 - (tt-tom17) New "Device model" setting: pick your model (AC2889, AC3221, CX3550, CX7550 or Generic) so the adapter shows the correct controls for your device
 - (tt-tom17) Added support for the AC3221 next-generation purifier (power, fan speed/mode, display brightness, child lock, beep and more)
+- (tt-tom17) The AC3221 now also reports its measurements and filter life: fine dust (PM2.5), allergen index, temperature, humidity and the remaining hours for both the pre-filter and the NanoProtect filter
 - (DrBakterius) Added support for the CX7550/01 tower fan (all 12 speeds, AutoAdapt, sleep, natural breeze, oscillation, writable timer, display settings and room temperature)
 - (tt-tom17) Fixed switches that did nothing when a script or visualisation wrote them as the text "true"/"false" instead of a real on/off value
 - (tt-tom17) The adapter now warns in the log when the selected model does not seem to match the connected device

--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -337,6 +337,32 @@ const MODEL_MAPPING = {
         D03130: { name: 'beep', options: { 100: true, 0: false }, control: true, rawType: 'number' },
         D0312A: { name: 'preferredIndex', options: { 1: 'pm2.5' }, control: true, rawType: 'number' },
         D03180: { name: 'autoPlusAi', options: { 1: true, 0: false }, control: true, rawType: 'number' },
+
+        // Sensors. This device reports its readings under new-gen D-codes instead of the classic
+        // pm25/iaql/rh/temp keys, so without these entries it exposes no measurements at all - every
+        // reading falls through to unknownStates.*. Friendly names are deliberately shared with the
+        // classic keys: a device only ever sends one of the two spellings, so they never collide.
+        // Confirmed twice over on the 2026-08-21 AC3221/13 log (GitHub #347): the values are
+        // plausible on their own (1-7 ug/m3, 42 %, 29.3-29.5 C) AND match kongo09's
+        // philips-airpurifier-coap "NEW2" table, which was derived independently.
+        D03221: { name: 'pm25', role: 'value', unit: 'µg/m³' },
+        D03120: { name: 'allergenIndex', role: 'value' },
+        D03125: { name: 'humidity', role: 'value.humidity', unit: '%' },
+        D03224: { name: 'temperature', scale: 10, type: 'number', role: 'value.temperature', unit: '°C' },
+
+        // Filter life, reported as two (remaining, total) pairs in hours. The strongest single piece
+        // of evidence for this reading: both pairs show the SAME elapsed runtime of 304 h
+        // (720 - 416 and 9600 - 9296), which two unrelated registers would not do by chance.
+        D0520D: { name: 'preFilterCleanInHours', filter: true, unit: 'hours' },
+        D05207: { name: 'preFilterTotalHours', filter: true, unit: 'hours' },
+        D0540E: { name: 'hepaFilterReplaceInHours', filter: true, unit: 'hours' },
+        D05408: { name: 'hepaFilterTotalHours', filter: true, unit: 'hours' },
+
+        // Deliberately left unmapped pending device-side confirmation: D03240 (error code, 0),
+        // D03137 (ambient light mode, 4) and D03134 (standby sensors, 1). kongo09's table names all
+        // three, but they were constant throughout the log, so nothing in the data confirms the
+        // reading. One reference alone is not enough to invent semantics - they stay in
+        // unknownStates.* until a tester varies them.
     },
 
     // No device-specific controls; useful as an explicit "read-only" choice.


### PR DESCRIPTION
The AC3221 reports its measurements under new-gen D-codes, so without these entries it exposes no
readings at all - everything falls through to unknownStates.*. Adds PM2.5, allergen index,
temperature and humidity plus the pre-filter and NanoProtect filter hours, confirmed on the
AC3221/13 log in #347 and independently matching kongo09's NEW2 table