### PR TITLE
fix: stop the adapter cleanly without DB and timer errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ More details are documented in [docs/CX7550.md](docs/CX7550.md).
     Placeholder for the next version (at the beginning of the line):
     ### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+
+- (tt-tom17) Fixed error messages ("DB closed", "setTimeout called, but adapter is shutting down") that appeared in the log every time the adapter was stopped or restarted (MatthiasBosch)
+
 ### 2.0.0 (2026-08-23)
 
 - (tt-tom17) New "Device model" setting: pick your model so the adapter shows the correct controls for your device

--- a/lib/coap.js
+++ b/lib/coap.js
@@ -268,6 +268,11 @@ class AirPurifier extends EventEmitter {
      * @param message connection message emitted when the session was previously disconnected
      */
     _markConnected(message) {
+        // Called from the observe stream, so it can still fire after destroy(). Arming the watchdog
+        // then logs "setTimeout called, but adapter is shutting down" and leaks a timer past unload.
+        if (this.destroyed) {
+            return;
+        }
         if (!this.connected) {
             this.connected = true;
             this._failedAttempts = 0;
@@ -335,6 +340,11 @@ class AirPurifier extends EventEmitter {
                 });
 
                 res.on('data', chunk => {
+                    // The observe request is closed asynchronously, so a packet already in flight can
+                    // arrive after destroy(). Dropping it here keeps the shutdown free of state writes.
+                    if (this.destroyed) {
+                        return;
+                    }
                     this.emit('debug', `Subscription data incoming: ${JSON.stringify(chunk)}`);
                     // decryptPayload may throw synchronously (e.g. corrupted message) - guard it so a single
                     // bad packet cannot crash the adapter, and surface the reason in the log.

--- a/lib/http.js
+++ b/lib/http.js
@@ -158,6 +158,11 @@ class AirPurifier extends EventEmitter {
             this._reconnect();
             return;
         }
+        // A sync already in flight when destroy() ran must not schedule the next poll - destroy()
+        // has cleared the timers, and re-arming one here would outlive the unload.
+        if (this.destroyed) {
+            return;
+        }
         this.reconnectTimeout && this.adapter.clearTimeout(this.reconnectTimeout);
         this.reconnectTimeout = null;
 
@@ -208,8 +213,11 @@ class AirPurifier extends EventEmitter {
                 await this.adapter.setStateAsync('info.key', this.clientKey, true);
             }
 
-            this.pingTimeout && this.adapter.clearTimeout(this.pingTimeout);
-            this.pingTimeout = this.adapter.setTimeout(() => this.sync(), this.aliveTimeout);
+            // Keep parsing the answer, but never re-arm the poll timer once destroy() ran.
+            if (!this.destroyed) {
+                this.pingTimeout && this.adapter.clearTimeout(this.pingTimeout);
+                this.pingTimeout = this.adapter.setTimeout(() => this.sync(), this.aliveTimeout);
+            }
 
             // An empty answer is normal for some firmwares - only a non-empty body that fails to parse
             // is worth an error. Parsing undefined used to log "Cannot parse: undefined" on every command.

--- a/main.js
+++ b/main.js
@@ -48,10 +48,17 @@ function startAdapter(options) {
             // is called when adapter shuts down - callback has to be called under any circumstances!
             unload: callback => {
                 try {
-                    adapter.setState('info.connection', false, true);
+                    // Tear the transport down FIRST: a status packet arriving after this point would
+                    // re-arm timers ("setTimeout called, but adapter is shutting down") and write states
+                    // into a database the controller is already closing.
                     airPurifier && airPurifier.destroy();
                     airPurifier = null;
-                    callback();
+                    // Await the final write before signalling "done". Reporting completion while the
+                    // write is still in flight makes the controller close the database underneath it,
+                    // which surfaced as "unhandled promise rejection: DB closed" on every stop.
+                    Promise.resolve(adapter.setState('info.connection', false, true))
+                        .catch(() => {})
+                        .then(() => callback());
                 } catch {
                     callback();
                 }
@@ -314,12 +321,20 @@ async function main() {
     airPurifier = new PurifierClass(adapter.config.host, adapter.config, adapter);
     adapter.log.debug('started');
 
+    // unload() clears airPurifier, so a late event from an already torn-down transport is
+    // recognisable here and must not reach the database any more.
     airPurifier.on('connected', connected => {
+        if (!airPurifier) {
+            return;
+        }
         adapter.log.debug(connected ? 'connected' : 'disconnected');
         adapter.setState('info.connection', connected, true);
     });
 
     airPurifier.on('status', async status => {
+        if (!airPurifier) {
+            return;
+        }
         adapter.log.debug(`STATUS: ${JSON.stringify(status)}`);
         await updateStatus(status);
     });

--- a/test/testCoap.js
+++ b/test/testCoap.js
@@ -105,6 +105,28 @@ describe('coap - connection handling', () => {
         ]);
     });
 
+    it('markConnected stays silent and arms no timer once the instance was destroyed', () => {
+        const inst = makeInstance();
+        const emitted = [];
+        inst.connected = false;
+        inst.destroyed = true;
+        inst.staleTimeout = 120000;
+        inst.pingTimeout = null;
+        inst.adapter = {
+            clearTimeout: () => {},
+            setTimeout: () => {
+                throw new Error('must not arm a watchdog timer after destroy');
+            },
+        };
+        inst.emit = (event, payload) => emitted.push([event, payload]);
+
+        inst._markConnected('Connected');
+
+        expect(inst.connected).to.equal(false);
+        expect(inst.pingTimeout).to.equal(null);
+        expect(emitted).to.deep.equal([]);
+    });
+
     it('keeps a quiet observe subscription open instead of rejecting on subscribe timeout', async () => {
         const inst = makeInstance();
         const originalRequest = coap.request;

--- a/test/testHttp.js
+++ b/test/testHttp.js
@@ -68,3 +68,21 @@ describe('http - control', () => {
         expect(message).to.contain('not connected yet');
     });
 });
+
+describe('http - shutdown', () => {
+    it('a control answer arriving after destroy does not re-arm the poll timer', async () => {
+        const { inst } = makeInstance({
+            setValues: async () => JSON.stringify({ pwr: '1' }),
+            key: null,
+        });
+        inst.destroyed = true;
+        inst.adapter.setTimeout = () => {
+            throw new Error('must not arm a poll timer after destroy');
+        };
+
+        const answer = await inst.control({ pwr: '1' });
+
+        expect(answer).to.deep.equal({ pwr: '1' });
+        expect(inst.pingTimeout).to.equal(undefined);
+    });
+});


### PR DESCRIPTION
Every stop of the instance logged three errors and three warnings, ending in "unhandled promise rejection: DB closed". Two independent causes:

unload() reported info.connection = false without awaiting the write and called the controller's callback right away, so js-controller closed the database underneath the running write. It now tears the transport down first and defers the callback until the final write settled.

Neither transport checked its destroyed flag on the asynchronous return paths, so a status packet or control answer arriving after destroy() re-armed a timer ("setTimeout called, but adapter is shutting down") and wrote states into a closing database. _markConnected() and the CoAP observe data handler now bail out when destroyed, and the HTTP sync/control paths no longer schedule the next poll after teardown.

Reported by MatthiasBosch in #347 (AC3221/13 restart log).